### PR TITLE
Change Separator For Fluids

### DIFF
--- a/src/main/java/zmaster587/libVulpes/util/XMLRecipeLoader.java
+++ b/src/main/java/zmaster587/libVulpes/util/XMLRecipeLoader.java
@@ -246,7 +246,7 @@ public class XMLRecipeLoader {
 		}
 		else if(node.getNodeName().equals("fluidStack")) {
 
-			String splitStr[] = node.getTextContent().split(" * ");
+			String splitStr[] = node.getTextContent().split("; ");
 			Fluid fluid;
 			if((fluid = FluidRegistry.getFluid(splitStr[0])) != null) {
 				int amount = 1000;
@@ -290,7 +290,7 @@ public class XMLRecipeLoader {
 		}
 
 		for(FluidStack stack : recipe.getFluidOutputs()) {
-			string += "\t\t\t<fluidStack>" + FluidRegistry.getDefaultFluidName(stack.getFluid()).split(":")[1] + " * " + stack.amount + "</fluidStack>\n";
+			string += "\t\t\t<fluidStack>" + FluidRegistry.getDefaultFluidName(stack.getFluid()).split(":")[1] + "; " + stack.amount + "</fluidStack>\n";
 		}
 
 		string += "\t\t</output>\n\t</Recipe>";

--- a/src/main/java/zmaster587/libVulpes/util/XMLRecipeLoader.java
+++ b/src/main/java/zmaster587/libVulpes/util/XMLRecipeLoader.java
@@ -246,7 +246,7 @@ public class XMLRecipeLoader {
 		}
 		else if(node.getNodeName().equals("fluidStack")) {
 
-			String splitStr[] = node.getTextContent().split(" ");
+			String splitStr[] = node.getTextContent().split(" * ");
 			Fluid fluid;
 			if((fluid = FluidRegistry.getFluid(splitStr[0])) != null) {
 				int amount = 1000;
@@ -290,7 +290,7 @@ public class XMLRecipeLoader {
 		}
 
 		for(FluidStack stack : recipe.getFluidOutputs()) {
-			string += "\t\t\t<fluidStack>" + FluidRegistry.getDefaultFluidName(stack.getFluid()).split(":")[1] + " " + stack.amount + "</fluidStack>\n";
+			string += "\t\t\t<fluidStack>" + FluidRegistry.getDefaultFluidName(stack.getFluid()).split(":")[1] + " * " + stack.amount + "</fluidStack>\n";
 		}
 
 		string += "\t\t</output>\n\t</Recipe>";

--- a/src/main/resources/assets/libvulpes/defaultrecipe.xml
+++ b/src/main/resources/assets/libvulpes/defaultrecipe.xml
@@ -1,7 +1,7 @@
 <!-->
 	<Recipe timeRequired="NUMBER" power="NUMBER">
 		<input>
-			<fluidStack>FLUID NAME SIZE</fluidStack>
+			<fluidStack>FLUID_NAME * SIZE</fluidStack>
 			<itemStack>ITEM_NAME SIZE META</itemStack>
 			<oreDict>OREDICT_NAME SIZE</oreDict>
         </input>

--- a/src/main/resources/assets/libvulpes/defaultrecipe.xml
+++ b/src/main/resources/assets/libvulpes/defaultrecipe.xml
@@ -1,12 +1,12 @@
 <!-->
 	<Recipe timeRequired="NUMBER" power="NUMBER">
 		<input>
-			<fluidStack>FLUID_NAME * SIZE</fluidStack>
+			<fluidStack>FLUID_NAME; SIZE</fluidStack>
 			<itemStack>ITEM_NAME SIZE META</itemStack>
 			<oreDict>OREDICT_NAME SIZE</oreDict>
         </input>
 		<output>
-			<fluidStack>FLUID_NAME SIZE</fluidStack>
+			<fluidStack>FLUID_NAME; SIZE</fluidStack>
 			<itemStack>ITEM_NAME SIZE META</itemStack>
 			<oreDict>OREDICT_NAME SIZE</oreDict>
 		</output>


### PR DESCRIPTION
Allows fluid names to be in much greater varieties, no more breaking on fluids that have spaces. YOU WILL NEED TO REGENERATE XMLs. Best way to do this is to either delete them and let them be created again, or change the " " separator to " * " manually.