### PR TITLE
Big code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,38 @@
-build/
-.gradle/
+# eclipse
+bin
+*.launch
+.settings
+.metadata
+.classpath
+.project
+
+# idea
+out
+*.ipr
+*.iws
+*.iml
+.idea
+
+# gradle
+build
+output
+.gradle
+
+# other
+eclipse
+run
 libVulpes.txt
-output/
-/asm
-/blueprints
-/build
-/config
-/gradle
-/logs
-/mods
-/resourcepacks
-/saves
-screenshots
-/gradle
-/asm
-/blueprints
 *.xcf
-/libs
-/models
-/crash-reports
+libs
+models
+
+# minecraft
+asm
+blueprints
+config
+logs
+mods
+resourcepacks
+saves
+screenshots
+crash-reports

--- a/src/main/java/zmaster587/libVulpes/LibVulpes.java
+++ b/src/main/java/zmaster587/libVulpes/LibVulpes.java
@@ -94,12 +94,14 @@ import zmaster587.libVulpes.util.ModCompatDictionary;
 import zmaster587.libVulpes.util.TeslaCapabilityProvider;
 import zmaster587.libVulpes.util.XMLRecipeLoader;
 
+import javax.annotation.Nonnull;
+
 @Mod(modid="libvulpes",name="Vulpes library",version="@MAJOR@.@MINOR@.@REVIS@.@BUILD@",useMetadata=true, dependencies="after:ic2;after:cofhcore;after:buildcraft|core;after:immersiveengineering")
 
 public class LibVulpes {
 	public static org.apache.logging.log4j.Logger logger = LogManager.getLogger("libVulpes");
 	public static int time = 0;
-	private static HashMap<Class, String> userModifiableRecipes = new HashMap<Class, String>();
+	private static HashMap<Class, String> userModifiableRecipes = new HashMap<>();
 
 	@Instance(value = "libvulpes")
 	public static LibVulpes instance;
@@ -111,6 +113,7 @@ public class LibVulpes {
 
 	private static CreativeTabs tabMultiblock = new CreativeTabs("multiBlock") {
 		@Override
+		@Nonnull
 		public ItemStack getTabIconItem() {
 			return new ItemStack(LibVulpesItems.itemLinker);// AdvancedRocketryItems.itemSatelliteIdChip;
 		}
@@ -119,6 +122,7 @@ public class LibVulpes {
 	public static CreativeTabs tabLibVulpesOres = new CreativeTabs("advancedRocketryOres") {
 
 		@Override
+		@Nonnull
 		public ItemStack getTabIconItem() {
 			return MaterialRegistry.getMaterialFromName("Copper").getProduct(AllowedProducts.getProductByName("ORE"));
 		}
@@ -134,7 +138,7 @@ public class LibVulpes {
     {
         MinecraftForge.EVENT_BUS.register(this);
 
-        //Initialze Blocks
+        //Initialize Blocks
         LibVulpesBlocks.blockPhantom = new BlockPhantom(Material.CIRCUITS).setUnlocalizedName("blockPhantom");
         LibVulpesBlocks.blockHatch = new BlockHatch(Material.IRON).setUnlocalizedName("hatch").setCreativeTab(tabMultiblock).setHardness(3f);
         LibVulpesBlocks.blockPlaceHolder = new BlockMultiblockPlaceHolder().setUnlocalizedName("placeHolder").setHardness(1f);
@@ -235,8 +239,7 @@ public class LibVulpes {
         //LibVulpesBlocks.registerBlock(LibVulpesBlocks.blockRFOutput.setRegistryName(LibVulpesBlocks.blockRFOutput.getUnlocalizedName()));
 
         //populate lists
-        Block motors[] = { LibVulpesBlocks.blockMotor, LibVulpesBlocks.blockAdvancedMotor, LibVulpesBlocks.blockEnhancedMotor, LibVulpesBlocks.blockEliteMotor };
-        LibVulpesBlocks.motors = motors;
+		LibVulpesBlocks.motors = new Block[]{ LibVulpesBlocks.blockMotor, LibVulpesBlocks.blockAdvancedMotor, LibVulpesBlocks.blockEnhancedMotor, LibVulpesBlocks.blockEliteMotor };
 
         //Register Tile
         GameRegistry.registerTileEntity(TileOutputHatch.class, "vulpesoutputHatch");
@@ -302,7 +305,7 @@ public class LibVulpes {
 	@EventHandler
 	public void preInit(FMLPreInitializationEvent event)
 	{
-		proxy.preinit();
+		proxy.preInit();
 		teslaHandler = null;
 		//Configuration
 		Configuration config = new Configuration(event.getSuggestedConfigurationFile());
@@ -385,19 +388,19 @@ public class LibVulpes {
 		
 		//Init TileMultiblock
 		//Item output
-		List<BlockMeta> list = new LinkedList<BlockMeta>();
+		List<BlockMeta> list = new LinkedList<>();
 		list.add(new BlockMeta(LibVulpesBlocks.blockHatch, 1));
 		list.add(new BlockMeta(LibVulpesBlocks.blockHatch, 9));
 		TileMultiBlock.addMapping('O', list);
 
 		//Item Inputs
-		list = new LinkedList<BlockMeta>();
+		list = new LinkedList<>();
 		list.add(new BlockMeta(LibVulpesBlocks.blockHatch, 0));
 		list.add(new BlockMeta(LibVulpesBlocks.blockHatch, 8));
 		TileMultiBlock.addMapping('I', list);
 
 		//Power input
-		list = new LinkedList<BlockMeta>();
+		list = new LinkedList<>();
 		list.add(new BlockMeta(LibVulpesBlocks.blockCreativeInputPlug, BlockMeta.WILDCARD));
 		list.add(new BlockMeta(LibVulpesBlocks.blockForgeInputPlug, BlockMeta.WILDCARD));
 		if(LibVulpesBlocks.blockRFBattery != null)
@@ -407,20 +410,20 @@ public class LibVulpes {
 		TileMultiBlock.addMapping('P', list);
 
 		//Power output
-		list = new LinkedList<BlockMeta>();
+		list = new LinkedList<>();
 		list.add(new BlockMeta(LibVulpesBlocks.blockForgeOutputPlug, BlockMeta.WILDCARD));
 		if(LibVulpesBlocks.blockRFOutput != null)
 			list.add(new BlockMeta(LibVulpesBlocks.blockRFOutput, BlockMeta.WILDCARD));
 		TileMultiBlock.addMapping('p', list);
 
 		//Liquid input
-		list = new LinkedList<BlockMeta>();
+		list = new LinkedList<>();
 		list.add(new BlockMeta(LibVulpesBlocks.blockHatch, 2));
 		list.add(new BlockMeta(LibVulpesBlocks.blockHatch, 10));
 		TileMultiBlock.addMapping('L', list);
 
 		//Liquid output
-		list = new LinkedList<BlockMeta>();
+		list = new LinkedList<>();
 		list.add(new BlockMeta(LibVulpesBlocks.blockHatch, 3));
 		list.add(new BlockMeta(LibVulpesBlocks.blockHatch, 11));
 		TileMultiBlock.addMapping('l', list);
@@ -436,39 +439,37 @@ public class LibVulpes {
 			try {
 				file.createNewFile();
 				BufferedReader inputStream = new BufferedReader(new InputStreamReader(getClass().getResourceAsStream("/assets/libvulpes/defaultrecipe.xml")));
-				
-				if(inputStream != null) {
-					BufferedWriter stream2 = new BufferedWriter(new FileWriter(file));
-					
-					
-					while(inputStream.ready()) {
-						stream2.write(inputStream.readLine() + "\n");
-					}
-					
-					
-					//Write recipes
-					
-					stream2.write("<Recipes useDefault=\"true\">\n");
-					for(IRecipe recipe : RecipesMachine.getInstance().getRecipes(clazz)) {
-						boolean writeable = true;
-						for (ItemStack stack : recipe.getOutput()) {
-							if(stack.hasTagCompound()) {
-								writeable = false;
-								break;
-							}
-						}
-						
-						if(((RecipesMachine.Recipe)recipe).outputToOnlyEmptySlots())
-							writeable = false;
-						
-						if(writeable)
-							stream2.write(XMLRecipeLoader.writeRecipe(recipe) + "\n");
-					}
-					stream2.write("</Recipes>");
-					stream2.close();
-					
-					inputStream.close();
+
+				BufferedWriter stream2 = new BufferedWriter(new FileWriter(file));
+
+
+				while(inputStream.ready()) {
+					stream2.write(inputStream.readLine() + "\n");
 				}
+
+
+				//Write recipes
+
+				stream2.write("<Recipes useDefault=\"true\">\n");
+				for(IRecipe recipe : RecipesMachine.getInstance().getRecipes(clazz)) {
+					boolean writeable = true;
+					for (ItemStack stack : recipe.getOutput()) {
+						if(stack.hasTagCompound()) {
+							writeable = false;
+							break;
+						}
+					}
+
+					if(((RecipesMachine.Recipe)recipe).outputToOnlyEmptySlots())
+						writeable = false;
+
+					if(writeable)
+						stream2.write(XMLRecipeLoader.writeRecipe(recipe) + "\n");
+				}
+				stream2.write("</Recipes>");
+				stream2.close();
+
+				inputStream.close();
 
 
 			} catch (IOException e) {

--- a/src/main/java/zmaster587/libVulpes/PacketID.java
+++ b/src/main/java/zmaster587/libVulpes/PacketID.java
@@ -6,6 +6,6 @@ public class PacketID {
 	ArrayList<Byte> idNum;
 	
 	public PacketID() {
-		idNum = new ArrayList<Byte>();
+		idNum = new ArrayList<>();
 	}
 }

--- a/src/main/java/zmaster587/libVulpes/api/IArmorComponent.java
+++ b/src/main/java/zmaster587/libVulpes/api/IArmorComponent.java
@@ -13,6 +13,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import zmaster587.libVulpes.client.ResourceIcon;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
 public interface IArmorComponent {
@@ -25,33 +26,32 @@ public interface IArmorComponent {
 	 * @param modules Inventory of the armorStack containing all modules inlcuding the current one
 	 * @param componentStack the ItemStack representing the current component being ticked
 	 */
-	public void onTick(World world, EntityPlayer player, ItemStack armorStack, IInventory modules, ItemStack componentStack);
+	void onTick(World world, EntityPlayer player, @Nonnull ItemStack armorStack, IInventory modules, @Nonnull ItemStack componentStack);
 	
 	/**
 	 * Called right before adding a component to the armor
 	 * @param world
-	 * @param player
-	 * @param itemStack the armor itemStack to add the component to
+	 * @param armorStack the armor itemStack to add the component to
 	 * @return true if it should be added false otherwise
 	 */
-	public boolean onComponentAdded(World world, ItemStack armorStack);
+	boolean onComponentAdded(World world, @Nonnull ItemStack armorStack);
 	
-	public void onComponentRemoved(World world, ItemStack armorStack);
+	void onComponentRemoved(World world, @Nonnull ItemStack armorStack);
 	
-	public void onArmorDamaged(EntityLivingBase entity, ItemStack armorStack, ItemStack componentStack, DamageSource source, int damage);
+	void onArmorDamaged(EntityLivingBase entity, @Nonnull ItemStack armorStack, @Nonnull ItemStack componentStack, DamageSource source, int damage);
 	
-	public boolean isAllowedInSlot(ItemStack componentStack, EntityEquipmentSlot armorType);
+	boolean isAllowedInSlot(@Nonnull ItemStack componentStack, EntityEquipmentSlot armorType);
 
 	@SideOnly(Side.CLIENT)
-	public void renderScreen(ItemStack componentStack, List<ItemStack> modules,
-			RenderGameOverlayEvent event, Gui gui);
+	void renderScreen(@Nonnull ItemStack componentStack, List<ItemStack> modules,
+					  RenderGameOverlayEvent event, Gui gui);
 	
 	/**
 	 * @param armorStack
-	 * @return The Icon for the HUD, null renders standard item
+	 * @return The Icon for the HUD, ItemStack.EMPTY renders standard item
 	 */
 	@SideOnly(Side.CLIENT)
-	public ResourceIcon getComponentIcon(ItemStack armorStack);
+	ResourceIcon getComponentIcon(@Nonnull ItemStack armorStack);
 
 
 }

--- a/src/main/java/zmaster587/libVulpes/api/IDismountHandler.java
+++ b/src/main/java/zmaster587/libVulpes/api/IDismountHandler.java
@@ -7,5 +7,5 @@ public interface IDismountHandler {
 	 * Called when a player entity attempts to dismount from this entity
 	 * @param entity
 	 */
-	public void handleDismount(Entity entity);
+	void handleDismount(Entity entity);
 }

--- a/src/main/java/zmaster587/libVulpes/api/IJetPack.java
+++ b/src/main/java/zmaster587/libVulpes/api/IJetPack.java
@@ -4,14 +4,16 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 
+import javax.annotation.Nonnull;
+
 public interface IJetPack {
-	public boolean isActive(ItemStack stack, EntityPlayer player);
+	boolean isActive(@Nonnull ItemStack stack, EntityPlayer player);
 	
-	public boolean isEnabled(ItemStack stack);
+	boolean isEnabled(@Nonnull ItemStack stack);
 	
-	public void setEnabledState(ItemStack stack, boolean state);
+	void setEnabledState(@Nonnull ItemStack stack, boolean state);
 	
-	public void onAccelerate(ItemStack stack, IInventory inv, EntityPlayer player);
+	void onAccelerate(@Nonnull ItemStack stack, IInventory inv, EntityPlayer player);
 	
-	public void changeMode(ItemStack stack, IInventory modules, EntityPlayer player);
+	void changeMode(@Nonnull ItemStack stack, IInventory modules, EntityPlayer player);
 }

--- a/src/main/java/zmaster587/libVulpes/api/IModularArmor.java
+++ b/src/main/java/zmaster587/libVulpes/api/IModularArmor.java
@@ -5,30 +5,33 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import zmaster587.libVulpes.util.IconResource;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
 public interface IModularArmor {
 	
-	public void addArmorComponent(World world, ItemStack armor, ItemStack componentStack, int slot);
-	
-	public ItemStack removeComponent(World world, ItemStack armor, int index);
-	
-	public List<ItemStack> getComponents(ItemStack armor);
+	void addArmorComponent(World world, @Nonnull ItemStack armor, @Nonnull ItemStack componentStack, int slot);
 
-	public ItemStack getComponentInSlot(ItemStack stack, int slot);
+	@Nonnull
+	ItemStack removeComponent(World world, @Nonnull ItemStack armor, int index);
+	
+	List<ItemStack> getComponents(@Nonnull ItemStack armor);
+
+	@Nonnull
+	ItemStack getComponentInSlot(@Nonnull ItemStack stack, int slot);
 	
 	//Returns a list of externally modifiable fluidtanks
-	public boolean canBeExternallyModified(ItemStack armor, int slot);
+	boolean canBeExternallyModified(@Nonnull ItemStack armor, int slot);
 	
-	public int getNumSlots(ItemStack stack);
+	int getNumSlots(@Nonnull ItemStack stack);
 	
-	public IInventory loadModuleInventory(ItemStack stack);
+	IInventory loadModuleInventory(@Nonnull ItemStack stack);
 	
-	public void saveModuleInventory(ItemStack stack, IInventory inv);
+	void saveModuleInventory(@Nonnull ItemStack stack, IInventory inv);
 	
 	//returns true if the stack is valid for the given slot
-	public boolean isItemValidForSlot(ItemStack stack, int slot);
+	boolean isItemValidForSlot(@Nonnull ItemStack stack, int slot);
 	
 	//Returns an IconResource to be displayed in the slot, if null default slot texture is used
-	public IconResource getResourceForSlot(int slot);
+	IconResource getResourceForSlot(int slot);
 }

--- a/src/main/java/zmaster587/libVulpes/api/ITimeModifier.java
+++ b/src/main/java/zmaster587/libVulpes/api/ITimeModifier.java
@@ -1,5 +1,5 @@
 package zmaster587.libVulpes.api;
 
 public interface ITimeModifier {
-	public float getTimeMult();
+	float getTimeMult();
 }

--- a/src/main/java/zmaster587/libVulpes/api/IToggleableMachine.java
+++ b/src/main/java/zmaster587/libVulpes/api/IToggleableMachine.java
@@ -1,5 +1,5 @@
 package zmaster587.libVulpes.api;
 
 public interface IToggleableMachine {
-	public boolean isRunning();
+	boolean isRunning();
 }

--- a/src/main/java/zmaster587/libVulpes/api/IUniversalEnergy.java
+++ b/src/main/java/zmaster587/libVulpes/api/IUniversalEnergy.java
@@ -2,7 +2,7 @@ package zmaster587.libVulpes.api;
 
 
 public interface IUniversalEnergy  {
-	public void setEnergyStored(int amt);
+	void setEnergyStored(int amt);
 
 	int extractEnergy(int amt, boolean simulate);
 
@@ -14,7 +14,7 @@ public interface IUniversalEnergy  {
 	
 	void setMaxEnergyStored(int max);
 
-	public boolean canReceive();
+	boolean canReceive();
 
-	public boolean canExtract();
+	boolean canExtract();
 }

--- a/src/main/java/zmaster587/libVulpes/api/IUniversalEnergyTransmitter.java
+++ b/src/main/java/zmaster587/libVulpes/api/IUniversalEnergyTransmitter.java
@@ -8,12 +8,12 @@ public interface IUniversalEnergyTransmitter {
 	 * @param side side requesting energy, UNKNOWN for internal tranmission or for teleportation
 	 * @return max energy units that can be transmitted
 	 */
-	public int getEnergyMTU(EnumFacing side);
+	int getEnergyMTU(EnumFacing side);
 	
 	/**
 	 * @param side side requesting energy, UNKNOWN for internal tranmission or for teleportation
 	 * @param simulate false to commit the change, true to only simulate
 	 * @return amount of energy actually transmitted
 	 */
-	public int transmitEnergy(EnumFacing side, boolean simulate);
+	int transmitEnergy(EnumFacing side, boolean simulate);
 }

--- a/src/main/java/zmaster587/libVulpes/api/LibVulpesBlocks.java
+++ b/src/main/java/zmaster587/libVulpes/api/LibVulpesBlocks.java
@@ -86,20 +86,9 @@ public class LibVulpesBlocks {
 				}
 
 				GameData.register_impl(itemBlock.setRegistryName(block.getRegistryName()));
-			} catch (InstantiationException e) {
+			} catch (InstantiationException | IllegalAccessException e) {
 				e.printStackTrace();
-			} catch (IllegalAccessException e) {
-				e.printStackTrace();
-			} catch (IllegalArgumentException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			} catch (InvocationTargetException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			} catch (NoSuchMethodException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			} catch (SecurityException e) {
+			} catch (IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();
 			}

--- a/src/main/java/zmaster587/libVulpes/api/material/AllowedProducts.java
+++ b/src/main/java/zmaster587/libVulpes/api/material/AllowedProducts.java
@@ -1,7 +1,5 @@
 package zmaster587.libVulpes.api.material;
 
-import net.minecraft.block.Block;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -29,7 +27,7 @@ public class AllowedProducts {
 		product.flagValue = currentFlagValue;
 		product.name = name;
 		currentFlagValue++;
-		MaterialRegistry.productBlockListMapping.put(product, new ArrayList<Block>());
+		MaterialRegistry.productBlockListMapping.put(product, new ArrayList<>());
 		map.put(name, product);
 		list.add(product);
 	}
@@ -43,8 +41,8 @@ public class AllowedProducts {
 	}
 	
 	private static short currentFlagValue = 1;
-	private static HashMap<String, AllowedProducts> map = new HashMap<String, AllowedProducts>();
-	private static List<AllowedProducts> list = new LinkedList<AllowedProducts>();
+	private static HashMap<String, AllowedProducts> map = new HashMap<>();
+	private static List<AllowedProducts> list = new LinkedList<>();
 	/*DUST,
 	INGOT,
 	GEM,

--- a/src/main/java/zmaster587/libVulpes/api/material/Material.java
+++ b/src/main/java/zmaster587/libVulpes/api/material/Material.java
@@ -5,6 +5,8 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
+import javax.annotation.Nonnull;
+
 public class Material {
 	String unlocalizedName, tool;
 	String[] oreDictNames;
@@ -50,8 +52,9 @@ public class Material {
 	/**
 	 * @param product
 	 * @param amount
-	 * @return Itemstack representing the product of this material, or null if nonexistant
+	 * @return ItemStack representing the product of this material, or ItemStack.EMPTY if nonexistent
 	 */
+	@Nonnull
 	public ItemStack getProduct(AllowedProducts product, int amount) {
 		/*ItemStack stack = OreDictionary.getOres(product.getName() + this.name()).get(0);
 			stack = stack.copy();
@@ -60,23 +63,23 @@ public class Material {
 
 		if(isVanilla()) {
 			if(this.unlocalizedName.equals("Iron")) {
-				if(product.getName().equals("INGOT"))
-					return new ItemStack(Items.IRON_INGOT, amount);
-				else if(product.getName().equals("ORE")) {
-					return new ItemStack(Blocks.IRON_ORE, amount);
-				}
-				else if(product.getName().equals("BLOCK")) {
-					return new ItemStack(Blocks.IRON_BLOCK, amount);
+				switch (product.getName()) {
+					case "INGOT":
+						return new ItemStack(Items.IRON_INGOT, amount);
+					case "ORE":
+						return new ItemStack(Blocks.IRON_ORE, amount);
+					case "BLOCK":
+						return new ItemStack(Blocks.IRON_BLOCK, amount);
 				}
 			}
 			if(this.unlocalizedName.equals("Gold")) {
-				if(product.getName().equals("INGOT"))
-					return new ItemStack(Items.GOLD_INGOT, amount);
-				else if(product.getName().equals("ORE")) {
-					return new ItemStack(Blocks.GOLD_ORE, amount);
-				}
-				else if(product.getName().equals("BLOCK")) {
-					return new ItemStack(Blocks.GOLD_BLOCK, amount);
+				switch (product.getName()) {
+					case "INGOT":
+						return new ItemStack(Items.GOLD_INGOT, amount);
+					case "ORE":
+						return new ItemStack(Blocks.GOLD_ORE, amount);
+					case "BLOCK":
+						return new ItemStack(Blocks.GOLD_BLOCK, amount);
 				}
 			}
 		}
@@ -91,8 +94,9 @@ public class Material {
 	}
 	/**
 	 * @param product
-	 * @return Itemstack of size 1 representing the product of this material, or null if nonexistant
+	 * @return ItemStack of size 1 representing the product of this material, or ItemStack.EMPTY if nonexistent
 	 */
+	@Nonnull
 	public ItemStack getProduct(AllowedProducts product) {
 		return getProduct(product,1);
 	}
@@ -157,7 +161,7 @@ public class Material {
 	/**
 	 * 
 	 * @param str 
-	 * @return the material corresponding to the string supplied or null if non existant
+	 * @return the material corresponding to the string supplied or null if nonexistent
 	 */
 	public static Material valueOfSafe(String str) {
 		try {

--- a/src/main/java/zmaster587/libVulpes/api/material/MaterialRegistry.java
+++ b/src/main/java/zmaster587/libVulpes/api/material/MaterialRegistry.java
@@ -22,24 +22,25 @@ import zmaster587.libVulpes.items.ItemOreProduct;
 import zmaster587.libVulpes.util.ItemStackMapping;
 import zmaster587.libVulpes.util.OreProductColorizer;
 
+import javax.annotation.Nonnull;
 import java.util.*;
 
 public class MaterialRegistry {
 
-	static HashMap<Object, MixedMaterial> mixedMaterialList = new HashMap<Object, MixedMaterial>();
+	static HashMap<Object, MixedMaterial> mixedMaterialList = new HashMap<>();
 	static HashMap<AllowedProducts, List<Block>> productBlockListMapping;
-	static List<MaterialRegistry> registries = new LinkedList<MaterialRegistry>();
+	static List<MaterialRegistry> registries = new LinkedList<>();
 
 	@SideOnly(Side.CLIENT)
 	static Object oreProductColorizer;
 
-	public HashMap<String, zmaster587.libVulpes.api.material.Material> strToMaterial = new HashMap<String, zmaster587.libVulpes.api.material.Material>();
-	public List<zmaster587.libVulpes.api.material.Material> materialList = new LinkedList<zmaster587.libVulpes.api.material.Material>();
+	public HashMap<String, zmaster587.libVulpes.api.material.Material> strToMaterial = new HashMap<>();
+	public List<zmaster587.libVulpes.api.material.Material> materialList = new LinkedList<>();
 	public Item[] oreProducts;
 
 
 	public MaterialRegistry() {
-		productBlockListMapping = new HashMap<AllowedProducts, List<Block>>();
+		productBlockListMapping = new HashMap<>();
 		registries.add(this);
 	}
 
@@ -58,7 +59,7 @@ public class MaterialRegistry {
 		for(Block block : getBlockListForProduct(AllowedProducts.getProductByName("BLOCK"))) {
 			if(block == null ||  Item.getItemFromBlock(block) == null)
 				continue;
-			Minecraft.getMinecraft().getBlockColors().registerBlockColorHandler((IBlockColor)oreProductColorizer, new Block[] {block});
+			Minecraft.getMinecraft().getBlockColors().registerBlockColorHandler((IBlockColor)oreProductColorizer, block);
 			Minecraft.getMinecraft().getItemColors().registerItemColorHandler((IItemColor)oreProductColorizer,  Item.getItemFromBlock(block));
 		}
 
@@ -66,7 +67,7 @@ public class MaterialRegistry {
 		for(Block block : getBlockListForProduct(AllowedProducts.getProductByName("COIL"))) {
 			if(block == null ||  Item.getItemFromBlock(block) == null)
 				continue;
-			Minecraft.getMinecraft().getBlockColors().registerBlockColorHandler((IBlockColor)oreProductColorizer, new Block[] { block});
+			Minecraft.getMinecraft().getBlockColors().registerBlockColorHandler((IBlockColor)oreProductColorizer, block);
 			Minecraft.getMinecraft().getItemColors().registerItemColorHandler((IItemColor)oreProductColorizer, Item.getItemFromBlock(block));
 		}
 
@@ -220,16 +221,16 @@ public class MaterialRegistry {
 
 	/**
 	 * @param stack the item stack to get the material of
-	 * @return {@link Materials} of the itemstack if it exists, otherwise null
+	 * @return {@link zmaster587.libVulpes.api.material.Material} of the itemstack if it exists, otherwise null
 	 */
-	public static zmaster587.libVulpes.api.material.Material getMaterialFromItemStack(ItemStack stack) {
+	public static zmaster587.libVulpes.api.material.Material getMaterialFromItemStack(@Nonnull ItemStack stack) {
 		Item item = stack.getItem();
 
 		//If items is an itemOreProduct it must have been registered
 
 		for(MaterialRegistry  registry : registries) {
 			for(Item i : registry.oreProducts) {
-				if(item == i && i != null) {
+				if(item == i) {
 					return registry.materialList.get(stack.getItemDamage());
 				}
 			}
@@ -252,26 +253,28 @@ public class MaterialRegistry {
 	/**
 	 * @param material
 	 * @param product
-	 * @return an itemstack of size one containing the product with the given material, or null if one does not exist
+	 * @return an ItemStack of size one containing the product with the given material, or ItemStack.EMPTY if one does not exist
 	 */
-	public static ItemStack getItemStackFromMaterialAndType(String material,AllowedProducts product) {
+	@Nonnull
+	public static ItemStack getItemStackFromMaterialAndType(String material, AllowedProducts product) {
 		return getItemStackFromMaterialAndType(material, product,1);
 	}
 
 	/**
-	 * @param material
+	 * @param ore
 	 * @param product
 	 * @param amount stackSize
-	 * @return an itemstack of stackSize amount containing the product with the given material, or null if one does not exist
+	 * @return an EtemStack of stackSize amount containing the product with the given material, or ItemStack.EMPTY if one does not exist
 	 */
-	public static ItemStack getItemStackFromMaterialAndType(String ore,AllowedProducts product, int amount) {
+	@Nonnull
+	public static ItemStack getItemStackFromMaterialAndType(String ore, AllowedProducts product, int amount) {
 		for(MaterialRegistry  registry : registries) {
 			zmaster587.libVulpes.api.material.Material ore2 = registry.strToMaterial.get(ore);
 
 			if(ore2 != null && product != null)
 				return new ItemStack( registry.oreProducts[product.ordinal()], amount, ore2.index);
 		}
-		return null;
+		return ItemStack.EMPTY;
 	}
 
 	/**
@@ -279,17 +282,18 @@ public class MaterialRegistry {
 	 * @param material new mixed material to create
 	 */
 	public static void registerMixedMaterial(MixedMaterial material) {
-		if(material.getInput() instanceof ItemStack)
-			mixedMaterialList.put( new ItemStackMapping((ItemStack) material.getInput()), material);
+		Object inputObj = material.getInput();
+		if(inputObj instanceof ItemStack && !((ItemStack) inputObj).isEmpty())
+			mixedMaterialList.put( new ItemStackMapping((ItemStack) inputObj), material);
 		else
-			mixedMaterialList.put( material.getInput(), material);
+			mixedMaterialList.put(inputObj, material);
 	}
 
 	/**
 	 * @param stack
 	 * @return {@link MixedMaterial} that makes up the item, null if the item is not registered
 	 */
-	public MixedMaterial getMixedMaterial(ItemStack stack) {
+	public MixedMaterial getMixedMaterial(@Nonnull ItemStack stack) {
 		return mixedMaterialList.get(new ItemStackMapping(stack));
 	}
 
@@ -301,7 +305,7 @@ public class MaterialRegistry {
 		return mixedMaterialList.get(str);
 	}
 
-	public static int getColorFromItemMaterial(ItemStack stack) {
+	public static int getColorFromItemMaterial(@Nonnull ItemStack stack) {
 
 		zmaster587.libVulpes.api.material.Material material = getMaterialFromItemStack(stack);
 		if(material == null) {
@@ -355,7 +359,7 @@ public class MaterialRegistry {
 	}
 
 	public static List<zmaster587.libVulpes.api.material.Material> getAllMaterials() {
-		List<zmaster587.libVulpes.api.material.Material> list = new LinkedList<zmaster587.libVulpes.api.material.Material>();
+		List<zmaster587.libVulpes.api.material.Material> list = new LinkedList<>();
 		for(MaterialRegistry registry : registries) {
 			list.addAll(registry.materialList);
 		}

--- a/src/main/java/zmaster587/libVulpes/api/material/MixedMaterial.java
+++ b/src/main/java/zmaster587/libVulpes/api/material/MixedMaterial.java
@@ -5,9 +5,9 @@ import net.minecraft.item.ItemStack;
 //TODO: needs work
 public class MixedMaterial {
 	
-	ItemStack[] product;
-	Object input;
-	Class process;
+	private ItemStack[] product;
+	private Object input;
+	private Class process;
 	
 	public MixedMaterial(Class process, Object input, ItemStack[] product) {
 		this.product = product;

--- a/src/main/java/zmaster587/libVulpes/block/BlockFullyRotatable.java
+++ b/src/main/java/zmaster587/libVulpes/block/BlockFullyRotatable.java
@@ -2,7 +2,6 @@ package zmaster587.libVulpes.block;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
-import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
@@ -12,6 +11,8 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+
+import javax.annotation.Nonnull;
 
 public class BlockFullyRotatable extends Block {
 	public static final PropertyEnum<EnumFacing> FACING =  PropertyEnum.create("facing", EnumFacing.class);
@@ -34,7 +35,7 @@ public class BlockFullyRotatable extends Block {
 
 	@Override
 	protected BlockStateContainer createBlockState() {
-		return new BlockStateContainer(this, new IProperty[]{FACING});
+		return new BlockStateContainer(this, FACING);
 	}
 
 	@Override
@@ -47,7 +48,7 @@ public class BlockFullyRotatable extends Block {
 	}
 	
 	@Override
-	public void onBlockPlacedBy(World world, BlockPos pos, IBlockState state, EntityLivingBase placer, ItemStack stack) {
+	public void onBlockPlacedBy(World world, BlockPos pos, IBlockState state, EntityLivingBase placer, @Nonnull ItemStack stack) {
 
 		if(Math.abs(placer.rotationPitch) > 60) {
 			world.setBlockState(pos, state.withProperty(FACING, placer.rotationPitch > 0 ? EnumFacing.UP : EnumFacing.DOWN), 2);

--- a/src/main/java/zmaster587/libVulpes/block/BlockMaterial.java
+++ b/src/main/java/zmaster587/libVulpes/block/BlockMaterial.java
@@ -14,8 +14,7 @@ import net.minecraft.world.World;
 import zmaster587.libVulpes.block.multiblock.BlockMultiblockStructure;
 import zmaster587.libVulpes.tile.TileMaterial;
 
-import java.util.ArrayList;
-import java.util.List;
+import javax.annotation.Nonnull;
 
 public class BlockMaterial extends BlockMultiblockStructure {
 
@@ -28,8 +27,9 @@ public class BlockMaterial extends BlockMultiblockStructure {
 	}
 
 	@Override
-	 public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player)
-     {
+	@Nonnull
+	public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player)
+	{
 		TileEntity tile = world.getTileEntity(pos);
 		int meta = 0;
 		if(tile instanceof TileMaterial) {

--- a/src/main/java/zmaster587/libVulpes/block/BlockMotor.java
+++ b/src/main/java/zmaster587/libVulpes/block/BlockMotor.java
@@ -11,6 +11,7 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import zmaster587.libVulpes.api.ITimeModifier;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
 public class BlockMotor extends RotatableBlock implements ITimeModifier {
@@ -33,14 +34,15 @@ public class BlockMotor extends RotatableBlock implements ITimeModifier {
 	}
 	 
 	 @Override
-	public void addInformation(ItemStack stack, World player,
-			List<String> tooltip, ITooltipFlag advanced) {
+	public void addInformation(@Nonnull ItemStack stack, World player,
+							   List<String> tooltip, ITooltipFlag advanced) {
 		super.addInformation(stack, player, tooltip, advanced);
 		
 		tooltip.add(String.format(ChatFormatting.GRAY + "Machine Speed: %.2f", 1/getTimeMult()));
 	}
 	
 	@Override
+	@Nonnull
 	public ItemStack getPickBlock(IBlockState state, RayTraceResult target,
 			World world, BlockPos pos, EntityPlayer player) {
 		return super.getPickBlock(state.getBlock().getDefaultState(), target, world, pos, player);

--- a/src/main/java/zmaster587/libVulpes/block/BlockOre.java
+++ b/src/main/java/zmaster587/libVulpes/block/BlockOre.java
@@ -2,7 +2,6 @@ package zmaster587.libVulpes.block;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
-import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyInteger;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
@@ -28,9 +27,8 @@ public class BlockOre extends Block implements INamedMetaBlock {
      */
     public IBlockState getStateFromMeta(int meta)
     {
-        IBlockState iblockstate = this.getDefaultState().withProperty(VARIANT, meta);
 
-        return iblockstate;
+		return this.getDefaultState().withProperty(VARIANT, meta);
     }
     
     @Override
@@ -41,7 +39,7 @@ public class BlockOre extends Block implements INamedMetaBlock {
     @Override
     protected BlockStateContainer createBlockState()
     {
-        return new BlockStateContainer(this, new IProperty[] {VARIANT});
+        return new BlockStateContainer(this, VARIANT);
     }
     
 	public AllowedProducts getProduct() {

--- a/src/main/java/zmaster587/libVulpes/block/BlockPhantom.java
+++ b/src/main/java/zmaster587/libVulpes/block/BlockPhantom.java
@@ -17,8 +17,10 @@ import net.minecraft.world.World;
 import zmaster587.libVulpes.tile.TileSchematic;
 import zmaster587.libVulpes.tile.multiblock.TilePlaceholder;
 
-import java.util.ArrayList;
-import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import javax.annotation.ParametersAreNullableByDefault;
 
 public class BlockPhantom extends Block {
 
@@ -44,31 +46,36 @@ public class BlockPhantom extends Block {
 	
 	
 	@Override
+	@ParametersAreNullableByDefault
 	public TileEntity createTileEntity(World world, IBlockState state) {
 		return new TileSchematic();
 	}
 	
 	@Override
+	@Nonnull
+	@ParametersAreNonnullByDefault
 	public ItemStack getPickBlock(IBlockState state, RayTraceResult target,
 			World world, BlockPos pos, EntityPlayer player) {
 		TileEntity tile = world.getTileEntity(pos);
 		
-		if(tile != null && tile instanceof TilePlaceholder && ((TilePlaceholder)tile).getReplacedState() != null) {
+		if(tile instanceof TilePlaceholder && ((TilePlaceholder) tile).getReplacedState() != null) {
 			Block block = ((TilePlaceholder)tile).getReplacedState().getBlock();
 			ItemStack stack = ((TilePlaceholder)tile).getReplacedState().getBlock().getPickBlock(((TilePlaceholder)tile).getReplacedState(), target, world, pos, player);
-			
-			
+
+
 			return stack;
 		}
 		return super.getPickBlock(state, target, world, pos, player);
 	}
 
 	@Override
+	@Nonnull
 	public EnumBlockRenderType getRenderType(IBlockState state) {
 		return EnumBlockRenderType.ENTITYBLOCK_ANIMATED;
 	}
 	
 	@Override
+	@ParametersAreNullableByDefault
 	public boolean shouldSideBeRendered(IBlockState blockState, IBlockAccess blockAccess, BlockPos pos, EnumFacing side) {
 		return false;
 	}
@@ -80,7 +87,7 @@ public class BlockPhantom extends Block {
 	
 
 	@Override
-	public boolean isReplaceable(IBlockAccess worldIn, BlockPos pos) {
+	public boolean isReplaceable(IBlockAccess worldIn, @Nullable BlockPos pos) {
 		return true;
 	}
 	

--- a/src/main/java/zmaster587/libVulpes/block/BlockTile.java
+++ b/src/main/java/zmaster587/libVulpes/block/BlockTile.java
@@ -1,7 +1,6 @@
 package zmaster587.libVulpes.block;
 
 import net.minecraft.block.material.Material;
-import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyBool;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
@@ -42,7 +41,7 @@ public class BlockTile extends RotatableBlock {
 
     protected BlockStateContainer createBlockState()
     {
-        return new BlockStateContainer(this, new IProperty[] {FACING, STATE});
+        return new BlockStateContainer(this, FACING, STATE);
     }
 	
     @Override
@@ -55,7 +54,7 @@ public class BlockTile extends RotatableBlock {
      * Convert the BlockState into the correct metadata value
      */
     public int getMetaFromState(IBlockState state) {
-    	return state.getValue(FACING).getIndex() | (state.getValue(STATE).booleanValue() ? 8 : 0);
+    	return state.getValue(FACING).getIndex() | (state.getValue(STATE) ? 8 : 0);
     }
     
 	public void setBlockState(World world, IBlockState state, BlockPos pos, boolean newState) {
@@ -135,15 +134,16 @@ public class BlockTile extends RotatableBlock {
 						Item oldItem = itemstack.getItem();
 						ItemStack oldStack = itemstack.copy();
 						itemstack.setCount(itemstack.getCount() - j1);
-						entityitem = new EntityItem(world, (double)((float)pos.getX() + f), (double)((float)pos.getY() + f1), (double)((float)pos.getZ() + f2), new ItemStack(oldItem, j1, itemstack.getItemDamage()));
+						entityitem = new EntityItem(world, (float)pos.getX() + f, (float)pos.getY() + f1, (float)pos.getZ() + f2, new ItemStack(oldItem, j1, itemstack.getItemDamage()));
 						float f3 = 0.05F;
-						entityitem.motionX = (double)((float)world.rand.nextGaussian() * f3);
-						entityitem.motionY = (double)((float)world.rand.nextGaussian() * f3 + 0.2F);
-						entityitem.motionZ = (double)((float)world.rand.nextGaussian() * f3);
+						entityitem.motionX = (float)world.rand.nextGaussian() * f3;
+						entityitem.motionY = (float)world.rand.nextGaussian() * f3 + 0.2F;
+						entityitem.motionZ = (float)world.rand.nextGaussian() * f3;
 
 						if (oldStack.hasTagCompound())
 						{
-							entityitem.getItem().setTagCompound((NBTTagCompound)oldStack.getTagCompound().copy());
+							NBTTagCompound tag = oldStack.getTagCompound();
+							entityitem.getItem().setTagCompound(tag == null ? null : tag.copy());
 						}
 						world.spawnEntity(entityitem);
 					}

--- a/src/main/java/zmaster587/libVulpes/block/INamedMetaBlock.java
+++ b/src/main/java/zmaster587/libVulpes/block/INamedMetaBlock.java
@@ -1,5 +1,5 @@
 package zmaster587.libVulpes.block;
 
 public interface INamedMetaBlock {
-	public String getUnlocalizedName(int damage);
+	String getUnlocalizedName(int damage);
 }

--- a/src/main/java/zmaster587/libVulpes/block/RotatableBlock.java
+++ b/src/main/java/zmaster587/libVulpes/block/RotatableBlock.java
@@ -3,7 +3,6 @@ package zmaster587.libVulpes.block;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockHorizontal;
 import net.minecraft.block.material.Material;
-import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
@@ -13,6 +12,8 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+
+import javax.annotation.Nonnull;
 
 public class RotatableBlock extends Block {
 
@@ -39,19 +40,20 @@ public class RotatableBlock extends Block {
 
 	@Override
 	protected BlockStateContainer createBlockState() {
-		return new BlockStateContainer(this, new IProperty[]{FACING});
+		return new BlockStateContainer(this, FACING);
 	}
 
 	
 	
 	@Override
+	@Nonnull
 	public IBlockState getStateForPlacement(World world, BlockPos pos,
 			EnumFacing facing, float hitX, float hitY, float hitZ, int meta,
 			EntityLivingBase placer, EnumHand hand) {
 		return  getDefaultState().withProperty(FACING, placer.getHorizontalFacing().getOpposite());//super.onBlockPlaced(worldIn, pos, facing, hitX, hitY, hitZ, meta, placer);
 	}
 	@Override
-	public void onBlockPlacedBy(World world, BlockPos pos, IBlockState state, EntityLivingBase placer, ItemStack stack) {
+	public void onBlockPlacedBy(World world, BlockPos pos, IBlockState state, EntityLivingBase placer, @Nonnull ItemStack stack) {
 
 		world.setBlockState(pos, state.withProperty(FACING, placer.getHorizontalFacing().getOpposite()), 2);
 	}

--- a/src/main/java/zmaster587/libVulpes/block/RotatableMachineBlock.java
+++ b/src/main/java/zmaster587/libVulpes/block/RotatableMachineBlock.java
@@ -2,7 +2,6 @@ package zmaster587.libVulpes.block;
 
 import com.mojang.realmsclient.gui.ChatFormatting;
 import net.minecraft.block.material.Material;
-import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyBool;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
@@ -21,6 +20,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import zmaster587.libVulpes.LibVulpes;
 import zmaster587.libVulpes.inventory.GuiHandler;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Random;
 
@@ -50,12 +50,12 @@ public class RotatableMachineBlock extends RotatableBlock {
 
 	@Override
 	protected BlockStateContainer createBlockState() {
-		return new BlockStateContainer(this, new IProperty[]{FACING, STATE});
+		return new BlockStateContainer(this, FACING, STATE);
 	}
 	
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void addInformation(ItemStack stack, World player, List<String> tooltip, ITooltipFlag advanced) {
+	public void addInformation(@Nonnull ItemStack stack, World player, List<String> tooltip, ITooltipFlag advanced) {
 		super.addInformation(stack, player, tooltip, advanced);
 		tooltip.add(ChatFormatting.ITALIC + LibVulpes.proxy.getLocalizedString("machine.tooltip.multiblock"));
 	}
@@ -75,7 +75,7 @@ public class RotatableMachineBlock extends RotatableBlock {
 			{
 				ItemStack itemstack = tileentitychest.getStackInSlot(j1);
 
-				if (itemstack != null)
+				if (!itemstack.isEmpty())
 				{
 					float f = this.random.nextFloat() * 0.8F + 0.1F;
 					float f1 = this.random.nextFloat() * 0.8F + 0.1F;
@@ -92,15 +92,16 @@ public class RotatableMachineBlock extends RotatableBlock {
 
 						itemstack.setCount(itemstack.getCount() - k1);
 
-						entityitem = new EntityItem(world, (double)((float)pos.getX() + f), (double)((float)pos.getY() + f1), (double)((float)pos.getZ() + f2), new ItemStack(itemstack.getItem(), k1, itemstack.getItemDamage()));
+						entityitem = new EntityItem(world, (float)pos.getX() + f, (float)pos.getY() + f1, (float)pos.getZ() + f2, new ItemStack(itemstack.getItem(), k1, itemstack.getItemDamage()));
 						float f3 = 0.05F;
-						entityitem.motionX = (double)((float)this.random.nextGaussian() * f3);
-						entityitem.motionY = (double)((float)this.random.nextGaussian() * f3 + 0.2F);
-						entityitem.motionZ = (double)((float)this.random.nextGaussian() * f3);
+						entityitem.motionX = (float)this.random.nextGaussian() * f3;
+						entityitem.motionY = (float)this.random.nextGaussian() * f3 + 0.2F;
+						entityitem.motionZ = (float)this.random.nextGaussian() * f3;
 
 						if (itemstack.hasTagCompound())
 						{
-							entityitem.getItem().setTagCompound((NBTTagCompound)itemstack.getTagCompound().copy());
+							NBTTagCompound tag = itemstack.getTagCompound();
+							entityitem.getItem().setTagCompound(tag == null ? null : tag.copy());
 						}
 					}
 				}
@@ -114,7 +115,7 @@ public class RotatableMachineBlock extends RotatableBlock {
 	public boolean onBlockActivated(World worldIn, BlockPos pos,
 			IBlockState state, EntityPlayer playerIn, EnumHand hand,
 			EnumFacing facing, float hitX, float hitY, float hitZ) {
-		//Handlue gui through modular system
+		//Handle gui through modular system
 		if(!worldIn.isRemote )
 			playerIn.openGui(LibVulpes.instance, GuiHandler.guiId.MODULAR.ordinal(), worldIn, pos.getX(), pos.getY(), pos.getZ());
 

--- a/src/main/java/zmaster587/libVulpes/block/multiblock/BlockHatch.java
+++ b/src/main/java/zmaster587/libVulpes/block/multiblock/BlockHatch.java
@@ -1,7 +1,6 @@
 package zmaster587.libVulpes.block.multiblock;
 
 import net.minecraft.block.material.Material;
-import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
@@ -18,8 +17,6 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidActionResult;
 import net.minecraftforge.fluids.FluidUtil;
-import net.minecraftforge.fluids.capability.IFluidHandler;
-import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import zmaster587.libVulpes.LibVulpes;
@@ -45,7 +42,7 @@ public class BlockHatch extends BlockMultiblockStructure {
 
 	protected BlockStateContainer createBlockState()
 	{
-		return new BlockStateContainer(this, new IProperty[] {VARIANT});
+		return new BlockStateContainer(this, VARIANT);
 	}
 
 	@Override
@@ -82,21 +79,21 @@ public class BlockHatch extends BlockMultiblockStructure {
 	public void breakBlock(World world, BlockPos pos, IBlockState state) {
 
 		TileEntity tile = world.getTileEntity(pos);
-		if(tile != null && tile instanceof IInventory) {
+		if(tile instanceof IInventory) {
 			IInventory inventory = (IInventory)tile;
 			for(int i = 0; i < inventory.getSizeInventory(); i++) {
 				ItemStack stack = inventory.getStackInSlot(i);
 
-				if(stack == null)
+				if(stack.isEmpty())
 					continue;
 
 				EntityItem entityitem = new EntityItem(world, pos.getX(), pos.getY(), pos.getZ(), stack);
 
 				float mult = 0.05F;
 
-				entityitem.motionX = (double)((float)this.random.nextGaussian() * mult);
-				entityitem.motionY = (double)((float)this.random.nextGaussian() * mult + 0.2F);
-				entityitem.motionZ = (double)((float)this.random.nextGaussian() * mult);
+				entityitem.motionX = (float)this.random.nextGaussian() * mult;
+				entityitem.motionY = (float)this.random.nextGaussian() * mult + 0.2F;
+				entityitem.motionZ = (float)this.random.nextGaussian() * mult;
 
 				world.spawnEntity(entityitem);
 			}
@@ -114,7 +111,7 @@ public class BlockHatch extends BlockMultiblockStructure {
 
 		boolean isPointer = blockAccess.getTileEntity(pos.offset(direction.getOpposite())) instanceof TilePointer;
 		if(isPointer)
-			isPointer = isPointer && !(((TilePointer)blockAccess.getTileEntity(pos.offset(direction.getOpposite()))).getMasterBlock() instanceof TileMultiBlock);
+			isPointer = !(((TilePointer)blockAccess.getTileEntity(pos.offset(direction.getOpposite()))).getMasterBlock() instanceof TileMultiBlock);
 
 		return blockState.getValue(VARIANT) < 8;
 
@@ -141,7 +138,7 @@ public class BlockHatch extends BlockMultiblockStructure {
 			}
 
 		}
-		//Handlue gui through modular system
+		//Handle gui through modular system
 		 else if((meta & 7) < 8 && !worldIn.isRemote)
 			playerIn.openGui(LibVulpes.instance, GuiHandler.guiId.MODULAR.ordinal(), worldIn, pos.getX(), pos.getY(), pos.getZ());
 

--- a/src/main/java/zmaster587/libVulpes/block/multiblock/BlockMultiblockMachine.java
+++ b/src/main/java/zmaster587/libVulpes/block/multiblock/BlockMultiblockMachine.java
@@ -18,6 +18,7 @@ import zmaster587.libVulpes.block.BlockTile;
 import zmaster587.libVulpes.inventory.modules.IModularInventory;
 import zmaster587.libVulpes.tile.multiblock.TileMultiBlock;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -47,7 +48,7 @@ public class BlockMultiblockMachine extends BlockTile {
 	
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void addInformation(ItemStack stack, World player, List<String> tooltip, ITooltipFlag advanced) {
+	public void addInformation(@Nonnull ItemStack stack, World player, List<String> tooltip, ITooltipFlag advanced) {
 		super.addInformation(stack, player, tooltip, advanced);
 		tooltip.add(ChatFormatting.DARK_GRAY + "" + ChatFormatting.ITALIC + LibVulpes.proxy.getLocalizedString("machine.tooltip.multiblock"));
 	}

--- a/src/main/java/zmaster587/libVulpes/block/multiblock/BlockMultiblockPlaceHolder.java
+++ b/src/main/java/zmaster587/libVulpes/block/multiblock/BlockMultiblockPlaceHolder.java
@@ -18,7 +18,10 @@ import net.minecraft.world.World;
 import zmaster587.libVulpes.tile.multiblock.TileMultiBlock;
 import zmaster587.libVulpes.tile.multiblock.TilePlaceholder;
 
-import java.util.ArrayList;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import javax.annotation.ParametersAreNullableByDefault;
 import java.util.List;
 
 /**
@@ -33,6 +36,7 @@ public class BlockMultiblockPlaceHolder extends BlockContainer {
 
 	//Make invisible
 	@Override
+	@ParametersAreNullableByDefault
 	public boolean shouldSideBeRendered(IBlockState blockState, IBlockAccess blockAccess, BlockPos pos, EnumFacing side) {
 		return false;
 	}
@@ -52,11 +56,14 @@ public class BlockMultiblockPlaceHolder extends BlockContainer {
 
 	//Make sure to get the block this one is storing rather than the placeholder itself
 	@Override
-	public ItemStack getPickBlock(IBlockState state, RayTraceResult target,
-			World world, BlockPos pos, EntityPlayer player) {
+	@Nonnull
+	public ItemStack getPickBlock(@Nullable IBlockState state, RayTraceResult target,
+			World world, @Nonnull BlockPos pos, EntityPlayer player) {
 		
 		TilePlaceholder tile = (TilePlaceholder)world.getTileEntity(pos);
-		return new ItemStack(tile.getReplacedState().getBlock(), 1, tile.getReplacedMeta());
+		if(tile != null && tile.getReplacedState() != null)
+			return new ItemStack(tile.getReplacedState().getBlock(), 1, tile.getReplacedMeta());
+		else return ItemStack.EMPTY;
 	}
 	
 	
@@ -76,7 +83,7 @@ public class BlockMultiblockPlaceHolder extends BlockContainer {
 			IBlockState newBlockState = tile.getReplacedState();
 			Block newBlock = newBlockState.getBlock();
 
-			if(newBlock != null && newBlock != Blocks.AIR && player.canHarvestBlock(newBlockState)) {
+			if(newBlock != Blocks.AIR && player.canHarvestBlock(newBlockState)) {
 				List<ItemStack> stackList = newBlock.getDrops(world, pos, newBlockState, 0);
 
 				for(ItemStack stack : stackList) {
@@ -89,10 +96,11 @@ public class BlockMultiblockPlaceHolder extends BlockContainer {
 	}
 
 	@Override
+	@ParametersAreNonnullByDefault
 	public void breakBlock(World world, BlockPos pos, IBlockState state) {
 		TileEntity tile = world.getTileEntity(pos);
 
-		if(tile != null && tile instanceof TilePlaceholder) {
+		if(tile instanceof TilePlaceholder) {
 			tile = ((TilePlaceholder)tile).getMasterBlock();
 			if(tile instanceof TileMultiBlock)
 				((TileMultiBlock)tile).deconstructMultiBlock(world, pos, true, world.getBlockState(tile.getPos()));
@@ -102,12 +110,13 @@ public class BlockMultiblockPlaceHolder extends BlockContainer {
 	}
 
 	@Override
+	@ParametersAreNullableByDefault
 	public TileEntity createTileEntity(World world, IBlockState state) {
 		return new TilePlaceholder();
 	}
 
 	@Override
-	public TileEntity createNewTileEntity(World worldIn, int meta) {
+	public TileEntity createNewTileEntity(@Nullable World worldIn, int meta) {
 		return new TilePlaceholder();
 	}
 }

--- a/src/main/java/zmaster587/libVulpes/block/multiblock/BlockMultiblockStructure.java
+++ b/src/main/java/zmaster587/libVulpes/block/multiblock/BlockMultiblockStructure.java
@@ -2,7 +2,6 @@ package zmaster587.libVulpes.block.multiblock;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
-import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyInteger;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
@@ -29,7 +28,7 @@ public class BlockMultiblockStructure extends Block {
 	
     protected BlockStateContainer createBlockState()
     {
-        return new BlockStateContainer(this, new IProperty[] {VARIANT});
+        return new BlockStateContainer(this, VARIANT);
     }
 	
     @Override
@@ -45,10 +44,8 @@ public class BlockMultiblockStructure extends Block {
 	/**
 	 * Turns the block invisible or in the case of BlockMultiBlockComponentVisible makes it create a tileEntity
 	 * @param world
-	 * @param x
-	 * @param y
-	 * @param z
-	 * @param meta
+	 * @param pos
+	 * @param state
 	 */
 	public void hideBlock(World world, BlockPos pos, IBlockState state) {
 		world.setBlockState(pos, state.withProperty(VARIANT, state.getValue(VARIANT) | 8));

--- a/src/main/java/zmaster587/libVulpes/cap/TeslaHandler.java
+++ b/src/main/java/zmaster587/libVulpes/cap/TeslaHandler.java
@@ -25,8 +25,7 @@ public class TeslaHandler {
 	
 	public static boolean hasTeslaCapability(ICapabilityProvider e, Capability<?> cap) {
 		if(TESLA_CONSUMER != null && TESLA_HOLDER != null && TESLA_PRODUCER != null) {
-			if(cap == TESLA_CONSUMER || cap == TESLA_HOLDER || cap == TESLA_PRODUCER)
-				return true;
+			return cap == TESLA_CONSUMER || cap == TESLA_HOLDER || cap == TESLA_PRODUCER;
 		}
 		return false;
 	}

--- a/src/main/java/zmaster587/libVulpes/client/ClientProxy.java
+++ b/src/main/java/zmaster587/libVulpes/client/ClientProxy.java
@@ -33,7 +33,7 @@ public class ClientProxy extends CommonProxy {
 	}
 	
 	@Override
-	public void preinit() {
+	public void preInit() {
 		OBJLoader.INSTANCE.addDomain("libvulpes");
 	}
 	
@@ -44,7 +44,7 @@ public class ClientProxy extends CommonProxy {
 	@Override
 	public void spawnParticle(String particle, World world, double x, double y, double z, double motionX, double motionY, double motionZ) {
 
-		if(particle == "errorBox") {
+		if(particle.equals("errorBox")) {
 			FxErrorBlock fx = new FxErrorBlock(world, x, y, z);
 			Minecraft.getMinecraft().effectRenderer.addEffect(fx);
 		}
@@ -67,7 +67,7 @@ public class ClientProxy extends CommonProxy {
 	@Override
 	public void preInitBlocks()
 	{
-		LinkedList<Item> blockItems = new LinkedList<Item>();
+		LinkedList<Item> blockItems = new LinkedList<>();
 		
 		blockItems.add(Item.getItemFromBlock(LibVulpesBlocks.blockAdvancedMotor));
 		blockItems.add(Item.getItemFromBlock(LibVulpesBlocks.blockAdvStructureBlock));

--- a/src/main/java/zmaster587/libVulpes/client/util/IndicatorBarImage.java
+++ b/src/main/java/zmaster587/libVulpes/client/util/IndicatorBarImage.java
@@ -29,7 +29,7 @@ public class IndicatorBarImage extends ProgressBarImage {
 		
 		gui.drawTexturedModalRect(x, y, backOffsetX, backOffsetY, backWidth, backHeight);
 		
-		int xProgress = 0, yProgress = 0;
+		int xProgress, yProgress;
 		
 		if(direction == EnumFacing.WEST)
 			xProgress = (int) (backWidth - insetX - ( ( backWidth - ( insetX*2 ) )*percent)) - foreHeight/2;

--- a/src/main/java/zmaster587/libVulpes/client/util/ProgressBarImage.java
+++ b/src/main/java/zmaster587/libVulpes/client/util/ProgressBarImage.java
@@ -150,10 +150,10 @@ public class ProgressBarImage {
         Tessellator tessellator = Tessellator.getInstance();
         BufferBuilder vertexbuffer = tessellator.getBuffer();
         vertexbuffer.begin(7, DefaultVertexFormats.POSITION_TEX);
-        vertexbuffer.pos((double)(x + 0), (double)(y + height), (double)zLevel).tex((double)((float)(textureX + 0) * 0.00390625F), (double)((float)(textureY + height) * 0.00390625F)).endVertex();
-        vertexbuffer.pos((double)(x + width), (double)(y + height), (double)zLevel).tex((double)((float)(textureX + width) * 0.00390625F), (double)((float)(textureY + height) * 0.00390625F)).endVertex();
-        vertexbuffer.pos((double)(x + width), (double)(y + 0), (double)zLevel).tex((double)((float)(textureX + width) * 0.00390625F), (double)((float)(textureY + 0) * 0.00390625F)).endVertex();
-        vertexbuffer.pos((double)(x + 0), (double)(y + 0), (double)zLevel).tex((double)((float)(textureX + 0) * 0.00390625F), (double)((float)(textureY + 0) * 0.00390625F)).endVertex();
+        vertexbuffer.pos(x    , y + height, zLevel).tex((float)(textureX    ) * 0.00390625F, (float)(textureY + height) * 0.00390625F).endVertex();
+        vertexbuffer.pos(x + width, y + height, zLevel).tex((float)(textureX + width) * 0.00390625F, (float)(textureY + height) * 0.00390625F).endVertex();
+        vertexbuffer.pos(x + width, y    , zLevel).tex((float)(textureX + width) * 0.00390625F, (float)(textureY    ) * 0.00390625F).endVertex();
+        vertexbuffer.pos(x    , y    , zLevel).tex((float)(textureX    ) * 0.00390625F, (float)(textureY    ) * 0.00390625F).endVertex();
         tessellator.draw();
     }
 	

--- a/src/main/java/zmaster587/libVulpes/common/CommonProxy.java
+++ b/src/main/java/zmaster587/libVulpes/common/CommonProxy.java
@@ -41,7 +41,7 @@ public class CommonProxy {
 		
 	}
 
-	public void preinit() {
+	public void preInit() {
 		// TODO Auto-generated method stub
 		
 	}

--- a/src/main/java/zmaster587/libVulpes/compat/InventoryCompat.java
+++ b/src/main/java/zmaster587/libVulpes/compat/InventoryCompat.java
@@ -5,6 +5,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import zmaster587.libVulpes.util.ZUtils;
 
+import javax.annotation.Nonnull;
+
 public class InventoryCompat {
 
 	static boolean buildCraft_injectable;
@@ -25,26 +27,26 @@ public class InventoryCompat {
 		if(buildCraft_injectable) {
 			return true;
 		}
-		return tile != null && tile instanceof IInventory && ZUtils.numEmptySlots((IInventory)tile) > 0;
+		return tile instanceof IInventory && ZUtils.numEmptySlots((IInventory) tile) > 0;
 	}
 	
-	public static boolean canInjectItems(TileEntity tile, ItemStack item) {
+	public static boolean canInjectItems(TileEntity tile, @Nonnull ItemStack item) {
 		
 		if(buildCraft_injectable) {
 			return true;
 		}
-		return tile != null && tile instanceof IInventory && (ZUtils.numEmptySlots((IInventory)tile) > 0 || ZUtils.doesInvHaveRoom(item, (IInventory)tile));
+		return tile instanceof IInventory && (ZUtils.numEmptySlots((IInventory) tile) > 0 || ZUtils.doesInvHaveRoom(item, (IInventory) tile));
 	}
 	
-	public static boolean canInjectItems(IInventory tile, ItemStack item) {
+	public static boolean canInjectItems(IInventory tile, @Nonnull ItemStack item) {
 		
 		if(buildCraft_injectable) {
 			return true;
 		}
-		return tile != null && (ZUtils.numEmptySlots((IInventory)tile) > 0 || ZUtils.doesInvHaveRoom(item, (IInventory)tile));
+		return tile != null && (ZUtils.numEmptySlots(tile) > 0 || ZUtils.doesInvHaveRoom(item, tile));
 	}
 	
-	public static void injectItem(Object tile, ItemStack item) {
+	public static void injectItem(Object tile, @Nonnull ItemStack item) {
 		if(buildCraft_injectable) {}
 			
 		ZUtils.mergeInventory(item, (IInventory)tile);

--- a/src/main/java/zmaster587/libVulpes/energy/IPower.java
+++ b/src/main/java/zmaster587/libVulpes/energy/IPower.java
@@ -5,15 +5,20 @@ import zmaster587.libVulpes.api.IUniversalEnergy;
 
 public interface IPower extends IUniversalEnergy {
 	
-	public boolean canConnectEnergy(EnumFacing facing);
+	boolean canConnectEnergy(EnumFacing facing);
 	
-	public int extractEnergy(EnumFacing dir, int maxExtract, boolean simulate);
+	int extractEnergy(EnumFacing dir, int maxExtract, boolean simulate);
 	
-	public int getEnergyStored(EnumFacing dir);
+	int getEnergyStored(EnumFacing dir);
 	
-	public int getMaxEnergyStored(EnumFacing dir);
+	int getMaxEnergyStored(EnumFacing dir);
 	
-	public int receiveEnergy(EnumFacing dir, int amt, boolean simulate);
-	
-	public int receiveEnergy(int amt, boolean simulate);
+	int receiveEnergy(EnumFacing dir, int amt, boolean simulate);
+
+	/**
+	 * @param amt
+	 * @param simulate
+	 * @return amount of energy used out of amt
+	 */
+	int receiveEnergy(int amt, boolean simulate);
 }

--- a/src/main/java/zmaster587/libVulpes/entity/fx/FxErrorBlock.java
+++ b/src/main/java/zmaster587/libVulpes/entity/fx/FxErrorBlock.java
@@ -46,10 +46,10 @@ public class FxErrorBlock extends Particle {
         worldRendererIn.finishDrawing();
         worldRendererIn.begin(GL11.GL_QUADS, DefaultVertexFormats.PARTICLE_POSITION_TEX_COLOR_LMAP);
         
-		worldRendererIn.pos((double)(f11 - rotationX * f10 - rotationXY * f10), (double)(f12 - rotationZ * f10), (double)(f13 - rotationYZ * f10 - rotationXZ * f10)).tex(1, 1).color(this.particleRed, this.particleGreen, this.particleBlue, 1f).lightmap(j, k).endVertex();
-		worldRendererIn.pos((double)(f11 - rotationX * f10 + rotationXY * f10), (double)(f12 + rotationZ * f10), (double)(f13 - rotationYZ * f10 + rotationXZ * f10)).tex(1, 0).color(this.particleRed, this.particleGreen, this.particleBlue, 1f).lightmap(j, k).endVertex();
-		worldRendererIn.pos((double)(f11 + rotationX * f10 + rotationXY * f10), (double)(f12 + rotationZ * f10), (double)(f13 + rotationYZ * f10 + rotationXZ * f10)).tex(0, 0).color(this.particleRed, this.particleGreen, this.particleBlue, 1f).lightmap(j, k).endVertex();
-		worldRendererIn.pos((double)(f11 + rotationX * f10 - rotationXY * f10), (double)(f12 - rotationZ * f10), (double)(f13 + rotationYZ * f10 - rotationXZ * f10)).tex(0, 1).color(this.particleRed, this.particleGreen, this.particleBlue, 1f).lightmap(j, k).endVertex();
+		worldRendererIn.pos(f11 - rotationX * f10 - rotationXY * f10, f12 - rotationZ * f10, f13 - rotationYZ * f10 - rotationXZ * f10).tex(1, 1).color(this.particleRed, this.particleGreen, this.particleBlue, 1f).lightmap(j, k).endVertex();
+		worldRendererIn.pos(f11 - rotationX * f10 + rotationXY * f10, f12 + rotationZ * f10, f13 - rotationYZ * f10 + rotationXZ * f10).tex(1, 0).color(this.particleRed, this.particleGreen, this.particleBlue, 1f).lightmap(j, k).endVertex();
+		worldRendererIn.pos(f11 + rotationX * f10 + rotationXY * f10, f12 + rotationZ * f10, f13 + rotationYZ * f10 + rotationXZ * f10).tex(0, 0).color(this.particleRed, this.particleGreen, this.particleBlue, 1f).lightmap(j, k).endVertex();
+		worldRendererIn.pos(f11 + rotationX * f10 - rotationXY * f10, f12 - rotationZ * f10, f13 + rotationYZ * f10 - rotationXZ * f10).tex(0, 1).color(this.particleRed, this.particleGreen, this.particleBlue, 1f).lightmap(j, k).endVertex();
 	
 		Tessellator.getInstance().draw();
 		worldRendererIn.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_LMAP_COLOR);

--- a/src/main/java/zmaster587/libVulpes/event/BucketHandler.java
+++ b/src/main/java/zmaster587/libVulpes/event/BucketHandler.java
@@ -17,8 +17,8 @@ import java.util.Map;
 public class BucketHandler {
 	
 	public static final BucketHandler INSTANCE = new BucketHandler();
-	private static Map<Block, Item> bucketMap = new HashMap<Block, Item>();
-	private static Map<Fluid, Item> itemMap = new HashMap<Fluid, Item>();
+	private static Map<Block, Item> bucketMap = new HashMap<>();
+	private static Map<Fluid, Item> itemMap = new HashMap<>();
 
 	@SubscribeEvent
 	public void onBucketFill(FillBucketEvent event) {

--- a/src/main/java/zmaster587/libVulpes/gui/GuiImageButton.java
+++ b/src/main/java/zmaster587/libVulpes/gui/GuiImageButton.java
@@ -88,10 +88,10 @@ public class GuiImageButton extends GuiButton {
 	        Tessellator tessellator = Tessellator.getInstance();
 	        BufferBuilder vertexbuffer = tessellator.getBuffer();
 	        vertexbuffer.begin(7, DefaultVertexFormats.POSITION_TEX);
-	        vertexbuffer.pos(x, y + height, (double)this.zLevel).tex(0, 1).endVertex();
-	        vertexbuffer.pos(x + width, y + height, (double)this.zLevel).tex( 1, 1).endVertex();
-	        vertexbuffer.pos(x + width, y, (double)this.zLevel).tex(1, 0).endVertex();
-	        vertexbuffer.pos(x, y, (double)this.zLevel).tex(0, 0).endVertex();
+	        vertexbuffer.pos(x, y + height, this.zLevel).tex(0, 1).endVertex();
+	        vertexbuffer.pos(x + width, y + height, this.zLevel).tex( 1, 1).endVertex();
+	        vertexbuffer.pos(x + width, y, this.zLevel).tex(1, 0).endVertex();
+	        vertexbuffer.pos(x, y, this.zLevel).tex(0, 0).endVertex();
 	        tessellator.draw();
 			
 			GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);

--- a/src/main/java/zmaster587/libVulpes/gui/GuiToggleButtonImage.java
+++ b/src/main/java/zmaster587/libVulpes/gui/GuiToggleButtonImage.java
@@ -64,10 +64,10 @@ public class GuiToggleButtonImage extends GuiButton {
 	        Tessellator tessellator = Tessellator.getInstance();
 	        BufferBuilder vertexbuffer = tessellator.getBuffer();
 	        vertexbuffer.begin(7, DefaultVertexFormats.POSITION_TEX);
-	        vertexbuffer.pos(x, y + height, (double)this.zLevel).tex(0, 1).endVertex();
-	        vertexbuffer.pos(x + width, y + height, (double)this.zLevel).tex( 1, 1).endVertex();
-	        vertexbuffer.pos(x + width, y, (double)this.zLevel).tex(1, 0).endVertex();
-	        vertexbuffer.pos(x, y, (double)this.zLevel).tex(0, 0).endVertex();
+	        vertexbuffer.pos(x, y + height, this.zLevel).tex(0, 1).endVertex();
+	        vertexbuffer.pos(x + width, y + height, this.zLevel).tex( 1, 1).endVertex();
+	        vertexbuffer.pos(x + width, y, this.zLevel).tex(1, 0).endVertex();
+	        vertexbuffer.pos(x, y, this.zLevel).tex(0, 0).endVertex();
 	        tessellator.draw();
 			
 			this.mouseDragged(minecraft, par2, par3);

--- a/src/main/java/zmaster587/libVulpes/gui/ILimitedItemSlotEntity.java
+++ b/src/main/java/zmaster587/libVulpes/gui/ILimitedItemSlotEntity.java
@@ -1,0 +1,9 @@
+package zmaster587.libVulpes.gui;
+
+import net.minecraft.item.ItemStack;
+
+import javax.annotation.Nonnull;
+
+public interface ILimitedItemSlotEntity {
+	boolean isItemValidForLimitedSlot(int slot, @Nonnull ItemStack itemstack);
+}

--- a/src/main/java/zmaster587/libVulpes/gui/IlimitedItemSlotEntity.java
+++ b/src/main/java/zmaster587/libVulpes/gui/IlimitedItemSlotEntity.java
@@ -1,7 +1,0 @@
-package zmaster587.libVulpes.gui;
-
-import net.minecraft.item.ItemStack;
-
-public interface IlimitedItemSlotEntity {
-	public boolean isItemValidForLimitedSlot(int slot, ItemStack itemstack);
-}

--- a/src/main/java/zmaster587/libVulpes/gui/SlotLimitedItem.java
+++ b/src/main/java/zmaster587/libVulpes/gui/SlotLimitedItem.java
@@ -4,6 +4,8 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
+import javax.annotation.Nonnull;
+
 public class SlotLimitedItem extends Slot {
 	
 	IInventory tile;
@@ -14,7 +16,7 @@ public class SlotLimitedItem extends Slot {
 	}
 	
 	@Override
-	public boolean isItemValid(ItemStack stack)
+	public boolean isItemValid(@Nonnull ItemStack stack)
 	{
 		return tile.isItemValidForSlot(this.slotNumber, stack);
 	}

--- a/src/main/java/zmaster587/libVulpes/gui/SlotListAllowed.java
+++ b/src/main/java/zmaster587/libVulpes/gui/SlotListAllowed.java
@@ -4,6 +4,7 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
+import javax.annotation.Nonnull;
 import java.util.Set;
 
 public class SlotListAllowed extends Slot {
@@ -16,10 +17,10 @@ public class SlotListAllowed extends Slot {
 	}
 	
 	@Override
-	public boolean isItemValid(ItemStack stack)
+	public boolean isItemValid(@Nonnull ItemStack stack)
 	{
-		for(ItemStack i : allowedItems){
-			if(i.isItemEqual(stack))
+		for(ItemStack itemStack : allowedItems){
+			if(itemStack.isItemEqual(stack))
 				return true;
 		}
 		return false;

--- a/src/main/java/zmaster587/libVulpes/gui/SlotMachineOutput.java
+++ b/src/main/java/zmaster587/libVulpes/gui/SlotMachineOutput.java
@@ -4,13 +4,15 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.SlotFurnaceOutput;
 import net.minecraft.item.ItemStack;
 
+import javax.annotation.Nonnull;
+
 public class SlotMachineOutput extends SlotFurnaceOutput {
 	
 	public SlotMachineOutput(IInventory inv, int slot, int x, int y) {
-		super(null,inv,slot,x,y);
+		super(null,inv,slot,x,y); // TODO: we can't pass null here
 	}
 	
-	//TODO: somthing here
+	//TODO: something here
 	@Override
-	protected void onCrafting(ItemStack par1ItemStack) {}
+	protected void onCrafting(@Nonnull ItemStack par1ItemStack) {}
 }

--- a/src/main/java/zmaster587/libVulpes/gui/SlotOreDict.java
+++ b/src/main/java/zmaster587/libVulpes/gui/SlotOreDict.java
@@ -5,6 +5,8 @@ import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
+import javax.annotation.Nonnull;
+
 public class SlotOreDict extends Slot {
 	
 	String acceptedNames;
@@ -15,7 +17,7 @@ public class SlotOreDict extends Slot {
 	}
 	
 	@Override
-	public boolean isItemValid(ItemStack stack)
+	public boolean isItemValid(@Nonnull ItemStack stack)
 	{
 		int oreId = OreDictionary.getOreID(acceptedNames);
 		if(oreId == -1)

--- a/src/main/java/zmaster587/libVulpes/gui/SlotOreDictList.java
+++ b/src/main/java/zmaster587/libVulpes/gui/SlotOreDictList.java
@@ -5,11 +5,12 @@ import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
+import javax.annotation.Nonnull;
 import java.util.Set;
 
 public class SlotOreDictList extends Slot {
 
-	Set<String> allowed;
+	private Set<String> allowed;
 
 	public SlotOreDictList(IInventory inv, int slot, int x, int y, Set<String> set) {
 		super(inv, slot, x, y);
@@ -17,7 +18,7 @@ public class SlotOreDictList extends Slot {
 	}
 
 	@Override
-	public boolean isItemValid(ItemStack stack)
+	public boolean isItemValid(@Nonnull ItemStack stack)
 	{
 		for(String acceptedNames : allowed) {
 			int oreId = OreDictionary.getOreID(acceptedNames);

--- a/src/main/java/zmaster587/libVulpes/gui/SlotSingleItem.java
+++ b/src/main/java/zmaster587/libVulpes/gui/SlotSingleItem.java
@@ -6,6 +6,8 @@ import net.minecraft.inventory.Slot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
+import javax.annotation.Nonnull;
+
 public class SlotSingleItem extends Slot {
 
 	private ItemStack acceptedItem;
@@ -21,14 +23,14 @@ public class SlotSingleItem extends Slot {
 		acceptedItem = new ItemStack(item);
 	}
 	
-	public SlotSingleItem(IInventory par1iInventory, int par2, int par3, int par4, ItemStack item) {
+	public SlotSingleItem(IInventory par1iInventory, int par2, int par3, int par4, @Nonnull ItemStack item) {
 		super(par1iInventory, par2, par3, par4);
 		acceptedItem = item;
 	}
 	
 	
 	@Override
-	public boolean isItemValid(ItemStack stack)
+	public boolean isItemValid(@Nonnull ItemStack stack)
 	{
 		return acceptedItem.isItemEqual(stack);
 	}

--- a/src/main/java/zmaster587/libVulpes/interfaces/ILinkableTile.java
+++ b/src/main/java/zmaster587/libVulpes/interfaces/ILinkableTile.java
@@ -5,6 +5,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
+import javax.annotation.Nonnull;
+
 public interface ILinkableTile {
 	
 	/**
@@ -15,7 +17,7 @@ public interface ILinkableTile {
 	 * @param world the world
 	 * @return true If link is allowed
 	 */
-	public boolean onLinkStart(ItemStack item, TileEntity entity, EntityPlayer player, World world);
+	boolean onLinkStart(@Nonnull ItemStack item, TileEntity entity, EntityPlayer player, World world);
 	
-	public boolean onLinkComplete(ItemStack item, TileEntity entity,EntityPlayer player, World world);
+	boolean onLinkComplete(@Nonnull ItemStack item, TileEntity entity, EntityPlayer player, World world);
 }

--- a/src/main/java/zmaster587/libVulpes/interfaces/INetworkEntity.java
+++ b/src/main/java/zmaster587/libVulpes/interfaces/INetworkEntity.java
@@ -5,5 +5,5 @@ import zmaster587.libVulpes.util.INetworkMachine;
 public interface INetworkEntity extends INetworkMachine {
 	
 	//Cannot overwrite Entity
-	public int getEntityId();
+	int getEntityId();
 }

--- a/src/main/java/zmaster587/libVulpes/interfaces/IRecipe.java
+++ b/src/main/java/zmaster587/libVulpes/interfaces/IRecipe.java
@@ -1,23 +1,22 @@
 package zmaster587.libVulpes.interfaces;
 
-import java.util.LinkedList;
 import java.util.List;
 
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
 public interface IRecipe {
-	public List<ItemStack> getOutput();
+	List<ItemStack> getOutput();
 	
-	public List<FluidStack> getFluidOutputs();
+	List<FluidStack> getFluidOutputs();
 	
-	public List<List<ItemStack>> getIngredients();
+	List<List<ItemStack>> getIngredients();
 	
-	public List<FluidStack> getFluidIngredients();
+	List<FluidStack> getFluidIngredients();
 	
-	public int getTime();
+	int getTime();
 	
-	public int getPower();
+	int getPower();
 	
-	public String getOreDictString(int slot);
+	String getOreDictString(int slot);
 }

--- a/src/main/java/zmaster587/libVulpes/inventory/ContainerModular.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/ContainerModular.java
@@ -10,6 +10,10 @@ import net.minecraft.inventory.IContainerListener;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
+import javax.annotation.Nonnull;
+
+//import javax.annotation.Nonnull;
+
 public class ContainerModular extends Container {
 
 	List<ModuleBase> modules;
@@ -74,9 +78,9 @@ public class ContainerModular extends Container {
 			for(int i = 0; i < module.numberOfChangesToSend(); i++) {
 				if(module.isUpdateRequired(i)) {
 
-					for (int j = 0; j < this.listeners.size(); ++j) {
-						module.sendChanges(this, ((IContainerListener)this.listeners.get(j)), moduleIndex, i);
-					}
+                    for (IContainerListener listener : this.listeners) {
+                        module.sendChanges(this, ((IContainerListener) listener), moduleIndex, i);
+                    }
 				}
 				moduleIndex++;
 			}
@@ -99,10 +103,11 @@ public class ContainerModular extends Container {
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack transferStackInSlot(EntityPlayer player, int slotId) {
 
 		ItemStack itemstack = ItemStack.EMPTY;
-		Slot slot = (Slot)this.inventorySlots.get(slotId);
+		Slot slot = this.inventorySlots.get(slotId);
 
 		if (slot != null && slot.getHasStack())
 		{
@@ -136,9 +141,9 @@ public class ContainerModular extends Container {
 	}
 	
 	 /**
-     * merges provided ItemStack with the first avaliable one in the container/player inventory
+     * merges provided ItemStack with the first available one in the container/player inventory
      */
-    /*protected boolean mergeItemStack(ItemStack p_75135_1_, int p_75135_2_, int p_75135_3_, boolean p_75135_4_)
+    /*protected boolean mergeItemStack(@Nonnull ItemStack p_75135_1_, int p_75135_2_, int p_75135_3_, boolean p_75135_4_)
     {
         boolean flag1 = false;
         int k = p_75135_2_;

--- a/src/main/java/zmaster587/libVulpes/inventory/GuiHandler.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/GuiHandler.java
@@ -6,7 +6,6 @@ import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.network.IGuiHandler;
-import zmaster587.libVulpes.LibVulpes;
 import zmaster587.libVulpes.inventory.modules.IModularInventory;
 
 public class GuiHandler implements IGuiHandler {
@@ -32,7 +31,7 @@ public class GuiHandler implements IGuiHandler {
 			ItemStack stack = player.getHeldItem(EnumHand.MAIN_HAND);
 			
 			//If there is latency or some desync odd things can happen so check for that
-			if(stack == null || !(stack.getItem() instanceof IModularInventory)) {
+			if(stack.isEmpty() || !(stack.getItem() instanceof IModularInventory)) {
 				return null;
 			}
 			
@@ -60,7 +59,7 @@ public class GuiHandler implements IGuiHandler {
 			ItemStack stack = player.getHeldItem(EnumHand.MAIN_HAND);
 			
 			//If there is latency or some desync odd things can happen so check for that
-			if(stack == null || !(stack.getItem() instanceof IModularInventory)) {
+			if(stack.isEmpty() || !(stack.getItem() instanceof IModularInventory)) {
 				return null;
 			}
 			

--- a/src/main/java/zmaster587/libVulpes/inventory/GuiModular.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/GuiModular.java
@@ -74,7 +74,7 @@ public class GuiModular extends GuiContainer {
 			int b) {
 		super.drawGuiContainerForegroundLayer(a, b);
 
-		this.fontRenderer.drawString(I18n.format(unlocalizedName, new Object[0]), 8, 6, 4210752);
+		this.fontRenderer.drawString(I18n.format(unlocalizedName), 8, 6, 4210752);
 
 		for(ModuleBase module : modules)
 			if(module.getVisible())
@@ -122,7 +122,7 @@ public class GuiModular extends GuiContainer {
 	}
 
 	public List<Rectangle> getExtraAreasCovered() {
-		List<Rectangle> list = new LinkedList<Rectangle>();
+		List<Rectangle> list = new LinkedList<>();
 		
 		for(ModuleBase module : modules) {
 				list.add(new Rectangle((width - xSize) / 2 + module.offsetX, (height - ySize) / 2 + module.offsetY, module.getSizeX(), module.getSizeY()));

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/IButtonInventory.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/IButtonInventory.java
@@ -10,6 +10,6 @@ public interface IButtonInventory {
 	 * @param buttonId id of the button pressed
 	 */
 	@SideOnly(Side.CLIENT)
-	public void onInventoryButtonPressed(int buttonId);
+	void onInventoryButtonPressed(int buttonId);
 	
 }

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/IDataSync.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/IDataSync.java
@@ -6,12 +6,12 @@ public interface IDataSync {
 	 * @param id assigned id of the data module
 	 * @param value value recieved from the server
 	 */
-	public void setData(int id, int value);
+	void setData(int id, int value);
 	
 	/**
 	 * 
 	 * @param id id of the module sync
 	 * @return the data associated with a moduleSync with the passed id
 	 */
-	public int getData(int id);
+	int getData(int id);
 }

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/IModularInventory.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/IModularInventory.java
@@ -9,10 +9,10 @@ public interface IModularInventory {
 	/**
 	 * @return a list of modules to add to the inventory
 	 */
-	public List<ModuleBase> getModules(int id, EntityPlayer player);
+	List<ModuleBase> getModules(int id, EntityPlayer player);
 	
-	public String getModularInventoryName();
+	String getModularInventoryName();
 	
-	public boolean canInteractWithContainer(EntityPlayer entity);
+	boolean canInteractWithContainer(EntityPlayer entity);
 	
 }

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/IProgressBar.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/IProgressBar.java
@@ -6,32 +6,32 @@ public interface IProgressBar {
 	 * @param id id of the progress bar 
 	 * @return progress from 0 to 1
 	 */
-	public float getNormallizedProgress(int id);
+	float getNormallizedProgress(int id);
 	
 	/**
 	 * Called on the client to sync information with the server
 	 * @param id id of the progress bar to update
 	 * @param progress progress data received from the server
 	 */
-	public void setProgress(int id, int progress);
+	void setProgress(int id, int progress);
 	
 	/**
 	 * @param id id of the progress bar
 	 * @return amount much progress
 	 */
-	public int getProgress(int id);
+	int getProgress(int id);
 	
 	/**
 	 * Gets the total progress, usually compared with getProgress to determine percent complete
 	 * @param id id of the progress bar
 	 * @return maximum amount of progress for this object
 	 */
-	public int getTotalProgress(int id);
+	int getTotalProgress(int id);
 	
 	/**
 	 * Called on the client to sync total progress with the server
 	 * @param id id of the progress bar to sync
 	 * @param progress progress received from the server
 	 */
-	public void setTotalProgress(int id, int progress);
+	void setTotalProgress(int id, int progress);
 }

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/ISelectionNotify.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/ISelectionNotify.java
@@ -1,9 +1,9 @@
 package zmaster587.libVulpes.inventory.modules;
 
 public interface ISelectionNotify {
-	public void onSelected(Object sender);
+	void onSelected(Object sender);
 	
-	public void onSelectionConfirmed(Object sender);
+	void onSelectionConfirmed(Object sender);
 
-	public void onSystemFocusChanged(Object sender);
+	void onSystemFocusChanged(Object sender);
 }

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/ISliderBar.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/ISliderBar.java
@@ -7,5 +7,5 @@ public interface ISliderBar extends IProgressBar {
 	 * @param id id of the progress bar to update
 	 * @param progress progress data received from the server
 	 */
-	public void setProgressByUser(int id, int progress);
+	void setProgressByUser(int id, int progress);
 }

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/IToggleButton.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/IToggleButton.java
@@ -5,5 +5,5 @@ public interface IToggleButton extends IButtonInventory {
 	 * Called when a module is toggled
 	 * @param module module that was toggled
 	 */
-	public void stateUpdated(ModuleBase module);
+	void stateUpdated(ModuleBase module);
 }

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleBase.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleBase.java
@@ -19,7 +19,6 @@ import zmaster587.libVulpes.LibVulpes;
 import zmaster587.libVulpes.gui.CommonResources;
 import zmaster587.libVulpes.inventory.GuiModular;
 
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -43,7 +42,7 @@ public abstract class ModuleBase {
 	protected ModuleBase(int offsetX, int offsetY) {
 		this.offsetX = offsetX;
 		this.offsetY = offsetY;
-		slotList = new LinkedList<Slot>();
+		slotList = new LinkedList<>();
 		enabled = true;
 		visible = true;
 	}
@@ -208,7 +207,7 @@ public abstract class ModuleBase {
 	 */
 	@SideOnly(Side.CLIENT)
 	public List<GuiButton> addButtons(int x, int y) {
-		return new LinkedList<GuiButton>();
+		return new LinkedList<>();
 	}
 
 	/**
@@ -224,7 +223,7 @@ public abstract class ModuleBase {
 	 * @return List of slots to add to this module
 	 */
 	public List<Slot> getSlots(Container container) {
-		return new LinkedList<Slot>();
+		return new LinkedList<>();
 	}
 
 	/**
@@ -236,21 +235,17 @@ public abstract class ModuleBase {
 	 * @param font fontrender
 	 */
 	@SideOnly(Side.CLIENT)
-	protected void drawTooltip(GuiContainer gui, List<String> textList ,int x, int y,float zLevel, FontRenderer font) {
+	protected void drawTooltip(GuiContainer gui, List<String> textList , int x, int y, float zLevel, FontRenderer font) {
 		GL11.glDisable(GL12.GL_RESCALE_NORMAL);
 		RenderHelper.disableStandardItemLighting();
 		GL11.glDisable(GL11.GL_LIGHTING);
 		GL11.glDisable(GL11.GL_DEPTH_TEST);
 		int k = 0;
-		Iterator iterator = textList.iterator();
 
-		while (iterator.hasNext())
-		{
-			String s = (String)iterator.next();
+		for (String s : textList) {
 			int l = font.getStringWidth(s);
 
-			if (l > k)
-			{
+			if (l > k) {
 				k = l;
 			}
 		}
@@ -276,7 +271,7 @@ public abstract class ModuleBase {
 
 		for (int i2 = 0; i2 < textList.size(); ++i2)
 		{
-			String s1 = (String)textList.get(i2);
+			String s1 = textList.get(i2);
 			font.drawStringWithShadow(s1, j2, k2, -1);
 
 			if (i2 == 0)
@@ -325,10 +320,10 @@ public abstract class ModuleBase {
 		BufferBuilder vertex = tessellator.getBuffer();
 		vertex.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_COLOR);
 		
-		vertex.pos((double)x2, (double)y1, (double)zLevel).color(f1, f2, f3, f).endVertex();
-		vertex.pos((double)x1, (double)y1, (double)zLevel).color(f1, f2, f3, f).endVertex();
-		vertex.pos((double)x1, (double)y2, (double)zLevel).color(f5, f6, f7, f4).endVertex();
-		vertex.pos((double)x2, (double)y2, (double)zLevel).color(f5, f6, f7, f4).endVertex();
+		vertex.pos(x2, y1, zLevel).color(f1, f2, f3, f).endVertex();
+		vertex.pos(x1, y1, zLevel).color(f1, f2, f3, f).endVertex();
+		vertex.pos(x1, y2, zLevel).color(f5, f6, f7, f4).endVertex();
+		vertex.pos(x2, y2, zLevel).color(f5, f6, f7, f4).endVertex();
 		tessellator.draw();
 		GL11.glShadeModel(GL11.GL_FLAT);
 		GL11.glDisable(GL11.GL_BLEND);

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleButton.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleButton.java
@@ -9,6 +9,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import zmaster587.libVulpes.gui.GuiImageButton;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -71,7 +72,7 @@ public class ModuleButton extends ModuleBase {
 	}*/
 
 	public void setImage(ResourceLocation[] images) {
-		((GuiImageButton)button).setButtonTexture(images);
+		button.setButtonTexture(images);
 	}
 
 
@@ -149,7 +150,7 @@ public class ModuleButton extends ModuleBase {
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
 		if(button != null)
-			this.enabled = button.enabled = enabled;
+			button.enabled = enabled;
 	}
 
 	/**
@@ -163,7 +164,7 @@ public class ModuleButton extends ModuleBase {
 	@SideOnly(Side.CLIENT)
 	public List<GuiButton> addButtons(int x, int y) {
 
-		List<GuiButton> list = new LinkedList<GuiButton>();
+		List<GuiButton> list = new LinkedList<>();
 
 		button = new GuiImageButton(buttonId, x + offsetX, y + offsetY, sizeX, sizeY, buttonImages);
 
@@ -205,12 +206,7 @@ public class ModuleButton extends ModuleBase {
 		if(tooltipText != null) {
 
 			if( isMouseOver(mouseX, mouseY) ) {
-				List<String> list = new LinkedList<String>();
-				for(String str : tooltipText.split("\n")) {
-
-					list.add(str);
-
-				}
+				List<String> list = new LinkedList<>(Arrays.asList(tooltipText.split("\n")));
 				this.drawTooltip(gui, list, mouseX, mouseY, zLevel, font);
 			}
 			//}

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleContainerPan.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleContainerPan.java
@@ -54,8 +54,8 @@ public class ModuleContainerPan extends ModuleBase {
 		this.screenSizeX = screenSizeX;
 		this.screenSizeY = screenSizeY;
 
-		buttonList = new LinkedList<GuiButton>();
-		staticButtonList = new LinkedList<GuiButton>();
+		buttonList = new LinkedList<>();
+		staticButtonList = new LinkedList<>();
 		slotList = new LinkedList<>();
 
 		this.backdrop = backdrop;
@@ -101,7 +101,7 @@ public class ModuleContainerPan extends ModuleBase {
 			staticButtonList.addAll(module.addButtons(x, y));
 		}
 
-		return new LinkedList<GuiButton>();
+		return new LinkedList<>();
 	}
 
 	public void setOffset(int x, int y) {
@@ -142,7 +142,7 @@ public class ModuleContainerPan extends ModuleBase {
 	
 	@Override
 	public List<Slot> getSlots(Container container) {
-		List<Slot> list = new LinkedList<Slot>();
+		List<Slot> list = new LinkedList<>();
 
 		for(ModuleBase module : this.moduleList) {
 			list.addAll(module.getSlots(container));
@@ -225,7 +225,7 @@ public class ModuleContainerPan extends ModuleBase {
 		//Handles buttons (mostly vanilla copy)
 		if(button == 0 && isMouseInBounds(0, 0, x, y)) {
 
-			List<GuiButton> fullButtonList = new LinkedList<GuiButton>();
+			List<GuiButton> fullButtonList = new LinkedList<>();
 			fullButtonList.addAll(buttonList);
 			fullButtonList.addAll(staticButtonList);
 
@@ -314,8 +314,8 @@ public class ModuleContainerPan extends ModuleBase {
 			}
 			else if(mouseLastX != x && mouseLastY != y) {
 
-				int deltaX = (int) ((k - mouseLastX));
-				int deltaY = (int) ((l - mouseLastY));
+				int deltaX = (k - mouseLastX);
+				int deltaY = (l - mouseLastY);
 
 				moveContainerInterior(deltaX, deltaY);
 

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleDualProgressBar.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleDualProgressBar.java
@@ -34,7 +34,7 @@ public class ModuleDualProgressBar extends ModuleProgress {
 	@Override
 	@SideOnly(Side.CLIENT)
 	protected List<String> getToolTip() {
-		List<String> modifiedList = new LinkedList<String>();
+		List<String> modifiedList = new LinkedList<>();
 		
 		for(String string : tooltip) {
 			int centerPoint = progress.getTotalProgress(id);

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleLiquidIndicator.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleLiquidIndicator.java
@@ -17,7 +17,6 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
 import net.minecraftforge.fml.relauncher.Side;
@@ -184,10 +183,10 @@ public class ModuleLiquidIndicator extends ModuleBase {
 		int xSize = 12;
 
 		if( relativeX > 0 && relativeX < xSize && relativeY > 0 && relativeY < ySize) {
-			List<String> list = new LinkedList<String>();
+			List<String> list = new LinkedList<>();
 			FluidStack fluidStack = tile.getTankProperties()[0].getContents();
 
-			if(fluidStack!= null) {
+			if(fluidStack != null) {
 
 				list.add(fluidStack.getLocalizedName()+": "+fluidStack.amount + " / " + tile.getTankProperties()[0].getCapacity() + " mB");
 
@@ -230,7 +229,7 @@ public class ModuleLiquidIndicator extends ModuleBase {
 			if(sprite == null)
 				gui.drawTexturedModalRect(offsetX + x + 1, offsetY + y + 1 + (ySize-(int)(percent*ySize)), 0, 0, xSize, (int)(percent*ySize));
 			else {
-				Minecraft.getMinecraft().renderEngine.bindTexture(Minecraft.getMinecraft().getTextureMapBlocks().LOCATION_BLOCKS_TEXTURE);
+				Minecraft.getMinecraft().renderEngine.bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
 				gui.drawTexturedModalRect(offsetX + x + 1, offsetY + y + 1 + (ySize-(int)(percent*ySize)), sprite, xSize, (int)(percent*ySize));
 			}
 			//gui.drawTexturedModelRectFrom(offsetX + x + 1, offsetY + y + 1 + (ySize-(int)(percent*ySize)), fluidIcon, xSize, (int)(percent*ySize));

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/ModulePower.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/ModulePower.java
@@ -50,7 +50,7 @@ public class ModulePower extends ModuleBase {
 		int relativeY = mouseY - offsetY;
 
 		if( relativeX > 0 && relativeX < barXSize && relativeY > 0 && relativeY < barYSize) {
-			List<String> list = new LinkedList<String>();
+			List<String> list = new LinkedList<>();
 			list.add(tile.getUniversalEnergyStored() + " / " + tile.getMaxEnergyStored() + " Power");
 
 			this.drawTooltip(gui, list, mouseX, mouseY, zLevel, font);

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleProgress.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleProgress.java
@@ -39,7 +39,7 @@ public class ModuleProgress extends ModuleBase {
 		if(tooltip == null || tooltip.isEmpty())
 			this.tooltip.clear();
 		else
-			this.tooltip = (List<String>)Arrays.asList(tooltip.split("\\n"));
+			this.tooltip = Arrays.asList(tooltip.split("\\n"));
 	}
 
 	@Override

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleRedstoneOutputButton.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleRedstoneOutputButton.java
@@ -5,7 +5,6 @@ import zmaster587.libVulpes.util.ZUtils.RedstoneState;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.inventory.GuiContainer;
-import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleScaledImage.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleScaledImage.java
@@ -74,10 +74,10 @@ public class ModuleScaledImage extends ModuleBase {
 		GlStateManager.color(alpha, alpha, alpha, alpha);
         BufferBuilder buff = Tessellator.getInstance().getBuffer();
         buff.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
-        buff.pos((double)(x + this.offsetX), (double)(y + this.offsetY + sizeY), (double)0).tex(minX, maxY).endVertex();
-        buff.pos((double)(x + this.offsetX + sizeX), (double)(y + this.offsetY + sizeY), (double)0).tex(maxX, maxY).endVertex();
-        buff.pos((double)(x + this.offsetX + sizeX), (double)(y + this.offsetY), (double)0).tex(maxX, minY).endVertex();
-        buff.pos((double)(x + this.offsetX), (double)(y + this.offsetY), (double)0).tex(minX, minY).endVertex();
+        buff.pos(x + this.offsetX, y + this.offsetY + sizeY, 0).tex(minX, maxY).endVertex();
+        buff.pos(x + this.offsetX + sizeX, y + this.offsetY + sizeY, 0).tex(maxX, maxY).endVertex();
+        buff.pos(x + this.offsetX + sizeX, y + this.offsetY, 0).tex(maxX, minY).endVertex();
+        buff.pos(x + this.offsetX, y + this.offsetY, 0).tex(minX, minY).endVertex();
         Tessellator.getInstance().draw();
         if(alpha < 1f) {
 			GL11.glColor4d(1f, 1f, 1f, 1f);

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleSlotButton.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleSlotButton.java
@@ -20,19 +20,21 @@ import org.lwjgl.opengl.GL11;
 import zmaster587.libVulpes.gui.CommonResources;
 import zmaster587.libVulpes.inventory.TextureResources;
 
+import javax.annotation.Nonnull;
+
 public class ModuleSlotButton extends ModuleButton {
 
 	ItemStack stack;
 	World worldObj;
 
-	public ModuleSlotButton(int offsetX, int offsetY, int buttonId, IButtonInventory tile, ItemStack slotDisplay,  World world ) {
+	public ModuleSlotButton(int offsetX, int offsetY, int buttonId, IButtonInventory tile, @Nonnull ItemStack slotDisplay, World world ) {
 
 		super(offsetX, offsetY, buttonId , "", tile, TextureResources.buttonNull, slotDisplay.getDisplayName() ,16,16);
 		stack = slotDisplay;
 		this.worldObj = world;
 	}
 
-	public ModuleSlotButton(int offsetX, int offsetY, int buttonId, IButtonInventory tile, ItemStack slotDisplay, String extraDisplay,  World world ) {
+	public ModuleSlotButton(int offsetX, int offsetY, int buttonId, IButtonInventory tile, @Nonnull ItemStack slotDisplay, String extraDisplay,  World world ) {
 
 		super(offsetX, offsetY, buttonId , "", tile, TextureResources.buttonNull, slotDisplay.getDisplayName() + " \n" + extraDisplay,16,16);
 		stack = slotDisplay;

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleText.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleText.java
@@ -6,6 +6,7 @@ import net.minecraft.client.renderer.GlStateManager;
 import org.lwjgl.opengl.GL11;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class ModuleText extends ModuleBase {
@@ -19,7 +20,7 @@ public class ModuleText extends ModuleBase {
 	public ModuleText(int offsetX, int offsetY, String text, int color) {
 		super(offsetX, offsetY);
 
-		this.text = new ArrayList<String>();
+		this.text = new ArrayList<>();
 		scale = 1f;
 		setText(text);
 		this.color = color;
@@ -41,9 +42,7 @@ public class ModuleText extends ModuleBase {
 	public void setText(String text) {
 
 		this.text.clear();
-		for(String str : text.split("\\n")) {
-			this.text.add(str);
-		}
+		this.text.addAll(Arrays.asList(text.split("\\n")));
 	}
 
 	public void setAlwaysOnTop(boolean alwaysOnTop) {
@@ -56,10 +55,10 @@ public class ModuleText extends ModuleBase {
 
 	public String getText() {
 
-		String str = "";
+		StringBuilder str = new StringBuilder();
 
 		for(String str2 : this.text) {
-			str += "\n" + str2;
+			str.append("\n").append(str2);
 		}
 
 		return str.substring(1);

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleTexturedLimitedSlotArray.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleTexturedLimitedSlotArray.java
@@ -1,6 +1,5 @@
 package zmaster587.libVulpes.inventory.modules;
 
-import zmaster587.libVulpes.inventory.TextureResources;
 import zmaster587.libVulpes.util.IconResource;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.inventory.GuiContainer;

--- a/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleToggleSwitch.java
+++ b/src/main/java/zmaster587/libVulpes/inventory/modules/ModuleToggleSwitch.java
@@ -54,7 +54,7 @@ public class ModuleToggleSwitch extends ModuleButton {
 	@SideOnly(Side.CLIENT)
 	public List<GuiButton> addButtons(int x, int y) {
 
-		List<GuiButton> list = new LinkedList<GuiButton>();
+		List<GuiButton> list = new LinkedList<>();
 
 		enabledButton = new GuiToggleButtonImage(0, x + offsetX, y + offsetY, sizeX, sizeY, buttonImages);
 		enabledButton.setState(currentState);

--- a/src/main/java/zmaster587/libVulpes/items/ItemBlockMeta.java
+++ b/src/main/java/zmaster587/libVulpes/items/ItemBlockMeta.java
@@ -4,6 +4,8 @@ import net.minecraft.block.Block;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 
+import javax.annotation.Nonnull;
+
 public class ItemBlockMeta extends  ItemBlock {
 
 	public ItemBlockMeta(Block p_i45326_1_) {
@@ -13,7 +15,7 @@ public class ItemBlockMeta extends  ItemBlock {
 	}
 
 	@Override
-	public String getUnlocalizedName(ItemStack stack) {
+	public String getUnlocalizedName(@Nonnull ItemStack stack) {
 		return super.getUnlocalizedName(stack) + "." + stack.getItemDamage();
 	}
 	

--- a/src/main/java/zmaster587/libVulpes/items/ItemIngredient.java
+++ b/src/main/java/zmaster587/libVulpes/items/ItemIngredient.java
@@ -7,6 +7,8 @@ import net.minecraft.util.NonNullList;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import javax.annotation.Nonnull;
+
 public class ItemIngredient extends Item
 {
 
@@ -38,9 +40,9 @@ public class ItemIngredient extends Item
     }
 
     @Override
-    public String getUnlocalizedName(ItemStack itemstack)
+    public String getUnlocalizedName(@Nonnull ItemStack itemstack)
     {
-        return (new StringBuilder()).append("item." + super.getUnlocalizedName().split(":")[1]).append(".")
-                .append(itemstack.getItemDamage()).toString();
+        return "item." + super.getUnlocalizedName().split(":")[1] + "." +
+                itemstack.getItemDamage();
     }
 }

--- a/src/main/java/zmaster587/libVulpes/items/ItemLinker.java
+++ b/src/main/java/zmaster587/libVulpes/items/ItemLinker.java
@@ -14,6 +14,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import zmaster587.libVulpes.interfaces.ILinkableTile;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
 public class ItemLinker extends Item {
@@ -31,7 +32,7 @@ public class ItemLinker extends Item {
 
 
 	@Override
-	public void addInformation(ItemStack par1ItemStack, World par2EntityPlayer, List par3List, ITooltipFlag par4)
+	public void addInformation(@Nonnull ItemStack par1ItemStack, World par2EntityPlayer, List<String> par3List, ITooltipFlag par4)
 	{
 		int y = getMasterY(par1ItemStack);
 
@@ -48,19 +49,19 @@ public class ItemLinker extends Item {
 		}
 	}
 
-	public static boolean isSet(ItemStack stack) {
+	public static boolean isSet(@Nonnull ItemStack stack) {
 		return getMasterY(stack) != 0;
 	}
 
 	@Deprecated
-	public static int getMasterX(ItemStack itemStack) {
+	public static int getMasterX(@Nonnull ItemStack itemStack) {
 		NBTTagCompound nbt = itemStack.getTagCompound();
 		nbt = nbt.getCompoundTag("MasterPos");
 
 		return nbt.getInteger("MasterX");
 	}
 	@Deprecated
-	public static int getMasterY(ItemStack itemStack) {
+	public static int getMasterY(@Nonnull ItemStack itemStack) {
 		NBTTagCompound nbt = itemStack.getTagCompound();
 
 		if(nbt == null)
@@ -71,14 +72,14 @@ public class ItemLinker extends Item {
 		return nbt.getInteger("MasterY");
 	}
 	@Deprecated
-	public static int getMasterZ(ItemStack itemStack) {
+	public static int getMasterZ(@Nonnull ItemStack itemStack) {
 		NBTTagCompound nbt = itemStack.getTagCompound();
 		nbt = nbt.getCompoundTag("MasterPos");
 
 		return nbt.getInteger("MasterZ");
 	}
 	
-	public static void setDimId(ItemStack itemStack, int id) {
+	public static void setDimId(@Nonnull ItemStack itemStack, int id) {
 		NBTTagCompound nbt;
 		if(!itemStack.hasTagCompound()) {
 			nbt = new NBTTagCompound();
@@ -91,40 +92,37 @@ public class ItemLinker extends Item {
 		
 	}
 	
-	public static int getDimId(ItemStack itemStack) {
+	public static int getDimId(@Nonnull ItemStack itemStack) {
 		NBTTagCompound nbt;
-		if(!itemStack.hasTagCompound()) {
+		if(!itemStack.hasTagCompound() || (nbt = itemStack.getTagCompound()) == null)
 			nbt = new NBTTagCompound();
-		}
-		else
-			nbt = itemStack.getTagCompound();
 		
 		return nbt.hasKey("dimId") ? nbt.getInteger("dimId") : -1;
 		
 	}
 
-	public static void setMasterX(ItemStack itemStack, int num) {
+	public static void setMasterX(@Nonnull ItemStack itemStack, int num) {
 		NBTTagCompound nbt = itemStack.getTagCompound();
 		nbt = nbt.getCompoundTag("MasterPos");
 
 		nbt.setInteger("MasterX", num);
 	}
 
-	public static void setMasterY(ItemStack itemStack, int num) {
+	public static void setMasterY(@Nonnull ItemStack itemStack, int num) {
 		NBTTagCompound nbt = itemStack.getTagCompound();
 		nbt = nbt.getCompoundTag("MasterPos");
 
 		nbt.setInteger("MasterY", num);
 	}
 
-	public static void setMasterZ(ItemStack itemStack, int num) {
+	public static void setMasterZ(@Nonnull ItemStack itemStack, int num) {
 		NBTTagCompound nbt = itemStack.getTagCompound();
 		nbt = nbt.getCompoundTag("MasterPos");
 
 		nbt.setInteger("MasterZ", num);
 	}
 
-	public static void setMasterCoords(ItemStack stack , int x, int y, int z) {
+	public static void setMasterCoords(@Nonnull ItemStack stack , int x, int y, int z) {
 		NBTTagCompound nbt;
 		if(!stack.hasTagCompound()) {
 			nbt = new NBTTagCompound();
@@ -141,11 +139,11 @@ public class ItemLinker extends Item {
 		nbt.setTag("MasterPos", tag);
 	}
 	
-	public static void setMasterCoords(ItemStack stack, BlockPos pos) {
+	public static void setMasterCoords(@Nonnull ItemStack stack, BlockPos pos) {
 		setMasterCoords(stack, pos.getX(), pos.getY(), pos.getZ());
 	}
 
-	public static BlockPos getMasterCoords(ItemStack stack ) {
+	public static BlockPos getMasterCoords(@Nonnull ItemStack stack ) {
 		if(!stack.hasTagCompound()) {
 
 			NBTTagCompound nbt = new NBTTagCompound();
@@ -156,7 +154,7 @@ public class ItemLinker extends Item {
 		return new BlockPos(getMasterX(stack),getMasterY(stack),getMasterZ(stack));
 	}
 	
-	public static void resetPosition(ItemStack itemStack) {
+	public static void resetPosition(@Nonnull ItemStack itemStack) {
 		NBTTagCompound position = new NBTTagCompound();
 
 		position.setInteger("MasterX", EMPTYSETTING);
@@ -167,6 +165,7 @@ public class ItemLinker extends Item {
 		itemStack.setTagInfo("MasterPos", position);
 	}
 	@Override
+	@Nonnull
 	public EnumActionResult onItemUse(EntityPlayer playerIn, World worldIn,
 			BlockPos pos, EnumHand hand, EnumFacing facing, float hitX,
 			float hitY, float hitZ) {
@@ -189,7 +188,7 @@ public class ItemLinker extends Item {
 		return EnumActionResult.FAIL;
 	}
 
-	protected void applySettings(ItemStack itemStack, ILinkableTile pad, EntityPlayer player, World world) {
+	protected void applySettings(@Nonnull ItemStack itemStack, ILinkableTile pad, EntityPlayer player, World world) {
 		if(!isSet(itemStack)) 
 			pad.onLinkStart(itemStack, (TileEntity)pad, player, world);
 		else

--- a/src/main/java/zmaster587/libVulpes/items/ItemMaterialBlock.java
+++ b/src/main/java/zmaster587/libVulpes/items/ItemMaterialBlock.java
@@ -3,6 +3,8 @@ package zmaster587.libVulpes.items;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemBlock;
 
+//import javax.annotation.Nonnull;
+
 public class ItemMaterialBlock extends ItemBlock {
 
 	public ItemMaterialBlock(Block block) {
@@ -10,7 +12,7 @@ public class ItemMaterialBlock extends ItemBlock {
 	}
 
 	/*@Override
-	public boolean placeBlockAt(ItemStack stack, EntityPlayer player,
+	public boolean placeBlockAt(@Nonnull ItemStack stack, EntityPlayer player,
 			World world, int x, int y, int z, int side, float hitX, float hitY,
 			float hitZ, int metadata) {
 		boolean succeeded = super.placeBlockAt(stack, player, world, x, y, z, side, hitX, hitY, hitZ, 0);
@@ -26,16 +28,16 @@ public class ItemMaterialBlock extends ItemBlock {
 	}
 
 	@Override
-	public String getUnlocalizedName(ItemStack stack) {
+	public String getUnlocalizedName(@Nonnull ItemStack stack) {
 		return this.getUnlocalizedName() + "." + getMaterial(stack).getUnlocalizedName();
 	}
 
 	@Override
-	public String getItemStackDisplayName(ItemStack itemstack) {
-		return StatCollector.translateToLocal("material." + getMaterial(itemstack).getUnlocalizedName() + ".name") + " " + StatCollector.translateToLocal(this.getUnlocalizedName());
+	public String getItemStackDisplayName(@Nonnull ItemStack itemStack) {
+		return StatCollector.translateToLocal("material." + getMaterial(itemStack).getUnlocalizedName() + ".name") + " " + StatCollector.translateToLocal(this.getUnlocalizedName());
 	}
 	
-	public Material.Materials getMaterial(ItemStack stack) {
+	public Material.Materials getMaterial(@Nonnull ItemStack stack) {
 		if(stack.getItemDamage() < 0 || stack.getItemDamage() >= Material.Materials.values().length)
 			return Material.Materials.values()[0];
 
@@ -44,7 +46,7 @@ public class ItemMaterialBlock extends ItemBlock {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public int getColorFromItemStack(ItemStack stack, int p_82790_2_) {
+	public int getColorFromItemStack(@Nonnull ItemStack stack, int p_82790_2_) {
 		return getMaterial(stack).getColor();
 	}*/
 

--- a/src/main/java/zmaster587/libVulpes/items/ItemOre.java
+++ b/src/main/java/zmaster587/libVulpes/items/ItemOre.java
@@ -7,6 +7,7 @@ import net.minecraft.util.text.translation.I18n;
 import zmaster587.libVulpes.block.BlockOre;
 import zmaster587.libVulpes.block.INamedMetaBlock;
 
+import javax.annotation.Nonnull;
 import java.util.Locale;
 
 public class ItemOre extends ItemBlock {
@@ -17,7 +18,7 @@ public class ItemOre extends ItemBlock {
 	}
 
 	@Override
-	public String getUnlocalizedName(ItemStack stack) {
+	public String getUnlocalizedName(@Nonnull ItemStack stack) {
 		return ((INamedMetaBlock)this.getBlock()).getUnlocalizedName(stack.getItemDamage());
 	}
 	
@@ -27,7 +28,7 @@ public class ItemOre extends ItemBlock {
 	}
 	
 	@Override
-    public String getItemStackDisplayName(ItemStack stack)
+    public String getItemStackDisplayName(@Nonnull ItemStack stack)
     {
 		String translate = "tile." + this.getUnlocalizedNameInefficiently(stack).substring(9) + "." + ((BlockOre)this.getBlock()).getProduct().name().toLowerCase(Locale.ENGLISH) + ".name";
 		if(I18n.canTranslate(translate))

--- a/src/main/java/zmaster587/libVulpes/items/ItemOreProduct.java
+++ b/src/main/java/zmaster587/libVulpes/items/ItemOreProduct.java
@@ -13,6 +13,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.oredict.OreDictionary;
 import zmaster587.libVulpes.api.material.Material;
 
+import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.Map.Entry;
 
@@ -28,7 +29,7 @@ public class ItemOreProduct extends Item {
 		setHasSubtypes(true);
 		setMaxDamage(0);
 		this.outputType = outputType;
-		properties = new HashMap<Integer, Material>();
+		properties = new HashMap<>();
 	}
 
 	public void registerItem(int meta, Material ore) {
@@ -55,7 +56,8 @@ public class ItemOreProduct extends Item {
 
 
 	@Override
-	public String getItemStackDisplayName(ItemStack itemstack) {
+	@Nonnull
+	public String getItemStackDisplayName(@Nonnull ItemStack itemstack) {
 
 		//Attempt to get a specific name first, then fall back
 		try {

--- a/src/main/java/zmaster587/libVulpes/network/BasePacket.java
+++ b/src/main/java/zmaster587/libVulpes/network/BasePacket.java
@@ -25,7 +25,7 @@ public abstract class BasePacket implements IMessage {
 	}
 
 	public static BasePacket constructPacket(int packetId) throws ProtocolException, InstantiationException, IllegalAccessException {
-		Class<? extends BasePacket> clazz = idMap.get(Integer.valueOf(packetId));
+		Class<? extends BasePacket> clazz = idMap.get(packetId);
 		if(clazz == null){
 			throw new ProtocolException("Protocol Exception!  Unknown Packet Id!");
 		} else {
@@ -56,7 +56,7 @@ public abstract class BasePacket implements IMessage {
 
 	public final int getPacketId() {
 		if(idMap.inverse().containsKey(getClass())) {
-			return idMap.inverse().get(getClass()).intValue();
+			return idMap.inverse().get(getClass());
 		} else {
 			throw new RuntimeException("Packet " + getClass().getSimpleName() + " is a missing mapping!");
 		}
@@ -101,7 +101,7 @@ public abstract class BasePacket implements IMessage {
 			return null;
 		}
 
-		public class executor implements Runnable {
+		public static class executor implements Runnable {
 
 			final Side side;
 			final BasePacket packet;
@@ -135,7 +135,7 @@ public abstract class BasePacket implements IMessage {
 			return null;
 		}
 
-		public class executor implements Runnable {
+		public static class executor implements Runnable {
 
 			final Side side;
 			final BasePacket packet;

--- a/src/main/java/zmaster587/libVulpes/network/INetworkItem.java
+++ b/src/main/java/zmaster587/libVulpes/network/INetworkItem.java
@@ -6,14 +6,16 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fml.relauncher.Side;
 
+import javax.annotation.Nonnull;
+
 public interface INetworkItem {
 	
 	//Writes data to the network given an id of what type of packet to write
-	public void writeDataToNetwork(ByteBuf out, byte id, ItemStack stack);
+	void writeDataToNetwork(ByteBuf out, byte id, @Nonnull ItemStack stack);
 	
 	//Reads data, stores read data to nbt to be passed to useNetworkData
-	public void readDataFromNetwork(ByteBuf in, byte packetId, NBTTagCompound nbt, ItemStack stack);
+	void readDataFromNetwork(ByteBuf in, byte packetId, NBTTagCompound nbt, @Nonnull ItemStack stack);
 	
 	//Applies changes from network
-	public void useNetworkData(EntityPlayer player, Side side, byte id, NBTTagCompound nbt, ItemStack stack);
+	void useNetworkData(EntityPlayer player, Side side, byte id, NBTTagCompound nbt, @Nonnull ItemStack stack);
 }

--- a/src/main/java/zmaster587/libVulpes/network/PacketChangeKeyState.java
+++ b/src/main/java/zmaster587/libVulpes/network/PacketChangeKeyState.java
@@ -15,7 +15,7 @@ public class PacketChangeKeyState extends BasePacket {
 		this.state = state;
 	}
 	
-	public PacketChangeKeyState() {};
+	public PacketChangeKeyState() {}
 	
 	@Override
 	public void write(ByteBuf out) {

--- a/src/main/java/zmaster587/libVulpes/network/PacketEntity.java
+++ b/src/main/java/zmaster587/libVulpes/network/PacketEntity.java
@@ -25,7 +25,7 @@ public class PacketEntity extends BasePacket {
 
 	public PacketEntity() {
 		nbt = new NBTTagCompound();
-	};
+	}
 
 	public PacketEntity(INetworkEntity machine, byte packetId) {
 		this();
@@ -88,7 +88,7 @@ public class PacketEntity extends BasePacket {
 			this.nbt = nbt;
 		}
 
-		if(ent != null && ent instanceof INetworkEntity) {
+		if(ent instanceof INetworkEntity) {
 			entity = (INetworkEntity)ent;
 			entity.readDataFromNetwork(in, packetId, nbt);
 		}
@@ -104,12 +104,12 @@ public class PacketEntity extends BasePacket {
 
 	@Override
 	public void executeServer(EntityPlayerMP player) {
-		execute((EntityPlayer)player, Side.SERVER);
+		execute(player, Side.SERVER);
 	}
 
 	@Override
 	public void executeClient(EntityPlayer player) {
-		execute((EntityPlayer)player, Side.CLIENT);
+		execute(player, Side.CLIENT);
 		if(entity == null) {
 			
 		}
@@ -144,7 +144,7 @@ public class PacketEntity extends BasePacket {
 			this.nbt = nbt;
 		}
 
-		if(ent != null && ent instanceof INetworkEntity) {
+		if(ent instanceof INetworkEntity) {
 			entity = (INetworkEntity)ent;
 			entity.readDataFromNetwork(buffer, packetId, nbt);
 		}

--- a/src/main/java/zmaster587/libVulpes/network/PacketHandler.java
+++ b/src/main/java/zmaster587/libVulpes/network/PacketHandler.java
@@ -37,7 +37,7 @@ public class PacketHandler {
 	
 	private static Class<?> defaultChannelPipeline;
 	private static int discriminatorNumber = 0;
-	static Codec codec = new Codec();
+	private static Codec codec = new Codec();
 	public static EnumMap<Side, FMLEmbeddedChannel> channels; //= NetworkRegistry.INSTANCE.newChannel("libVulpes", codec);
 	
 	public static PacketHandler INSTANCE = new PacketHandler();
@@ -53,7 +53,7 @@ public class PacketHandler {
 	}
 	
     private static Method generateName;
-    {
+    static {
         try
         {
             defaultChannelPipeline = Class.forName("io.netty.channel.DefaultChannelPipeline");
@@ -112,7 +112,7 @@ public class PacketHandler {
 
     private <REPLY extends IMessage, REQ extends IMessage> SimpleChannelHandlerWrapper<REQ, REPLY> getHandlerWrapper(IMessageHandler<? super REQ, ? extends REPLY> messageHandler, Side side, Class<REQ> requestType)
     {
-        return new SimpleChannelHandlerWrapper<REQ, REPLY>(messageHandler, side, requestType);
+        return new SimpleChannelHandlerWrapper<>(messageHandler, side, requestType);
     }
     
     private String generateName(ChannelPipeline pipeline, ChannelHandler handler)
@@ -178,7 +178,7 @@ public class PacketHandler {
 
 		@Override
 		public void encodeInto(ChannelHandlerContext ctx, BasePacket msg,
-				ByteBuf data) throws Exception {
+				ByteBuf data) {
 			msg.write(data);
 		}
 
@@ -207,7 +207,7 @@ public class PacketHandler {
 
 		}
 		
-		public class executorServer implements Runnable {
+		public static class executorServer implements Runnable {
 
 			final Side side;
 			final BasePacket packet;
@@ -231,8 +231,7 @@ public class PacketHandler {
 	private static final class HandlerClient extends SimpleChannelInboundHandler<BasePacket>
 	{
 		@Override
-		protected void channelRead0(ChannelHandlerContext ctx, BasePacket packet) throws Exception
-		{
+		protected void channelRead0(ChannelHandlerContext ctx, BasePacket packet) {
 			Minecraft mc = Minecraft.getMinecraft();
 			packet.executeClient(mc.player); //actionClient(mc.theWorld, );
 		}
@@ -241,8 +240,7 @@ public class PacketHandler {
 	private static final class HandlerServer extends SimpleChannelInboundHandler<BasePacket>
 	{
 		@Override
-		protected void channelRead0(ChannelHandlerContext ctx, BasePacket packet) throws Exception
-		{
+		protected void channelRead0(ChannelHandlerContext ctx, BasePacket packet) {
 			if (FMLCommonHandler.instance().getEffectiveSide().isClient())
 			{
 				// nothing on the client thread

--- a/src/main/java/zmaster587/libVulpes/network/PacketItemModifcation.java
+++ b/src/main/java/zmaster587/libVulpes/network/PacketItemModifcation.java
@@ -18,16 +18,16 @@ import java.io.IOException;
 
 public class PacketItemModifcation extends BasePacket {
 
-	NBTTagCompound nbt;
+	private NBTTagCompound nbt;
 
-	byte packetId;
-	int entityId;
-	EntityPlayer entity;
-	INetworkItem machine;
+	private byte packetId;
+	private int entityId;
+	private EntityPlayer entity;
+	private INetworkItem machine;
 
 	public PacketItemModifcation() {
 		nbt = new NBTTagCompound();
-	};
+	}
 
 	public PacketItemModifcation(INetworkItem machine, EntityPlayer entity, byte packetId) {
 		this();
@@ -100,9 +100,9 @@ public class PacketItemModifcation extends BasePacket {
 			this.nbt = nbt;
 		}
 
-		if(ent != null && ent instanceof EntityPlayer) {
+		if(ent instanceof EntityPlayer) {
 			ItemStack itemStack = ((EntityPlayer)ent).getHeldItem(EnumHand.MAIN_HAND);
-			if(itemStack != null && itemStack.getItem() instanceof INetworkItem) {
+			if(!itemStack.isEmpty() && itemStack.getItem() instanceof INetworkItem) {
 				((INetworkItem)itemStack.getItem()).readDataFromNetwork(in, packetId, nbt, itemStack);
 			}
 		}
@@ -115,7 +115,7 @@ public class PacketItemModifcation extends BasePacket {
 
 		if(player != null) {
 			ItemStack itemStack = player.getHeldItem(EnumHand.MAIN_HAND);
-			if(itemStack != null && itemStack.getItem() instanceof INetworkItem) {
+			if(!itemStack.isEmpty() && itemStack.getItem() instanceof INetworkItem) {
 				((INetworkItem)itemStack.getItem()).useNetworkData(player, side, packetId, nbt, itemStack);
 			}
 		}
@@ -126,12 +126,12 @@ public class PacketItemModifcation extends BasePacket {
 
 	@Override
 	public void executeServer(EntityPlayerMP player) {
-		execute((EntityPlayer)player, Side.SERVER);
+		execute(player, Side.SERVER);
 	}
 
 	@Override
 	public void executeClient(EntityPlayer player) {
-		execute((EntityPlayer)player, Side.CLIENT);
+		execute(player, Side.CLIENT);
 	}
 
 	@Override
@@ -162,9 +162,9 @@ public class PacketItemModifcation extends BasePacket {
 			this.nbt = nbt;
 		}
 
-		if(ent != null && ent instanceof EntityPlayer) {
+		if(ent instanceof EntityPlayer) {
 			ItemStack itemStack = ((EntityPlayer)ent).getHeldItem(EnumHand.MAIN_HAND);
-			if(itemStack != null && itemStack.getItem() instanceof INetworkItem) {
+			if(!itemStack.isEmpty() && itemStack.getItem() instanceof INetworkItem) {
 				((INetworkItem)itemStack.getItem()).readDataFromNetwork(in, packetId, nbt, itemStack);
 			}
 		}

--- a/src/main/java/zmaster587/libVulpes/network/PacketMachine.java
+++ b/src/main/java/zmaster587/libVulpes/network/PacketMachine.java
@@ -24,7 +24,7 @@ public class PacketMachine extends BasePacket {
 
 	public PacketMachine() {
 		nbt = new NBTTagCompound();
-	};
+	}
 
 	public PacketMachine(INetworkMachine machine, byte packetId) {
 		this();
@@ -62,7 +62,7 @@ public class PacketMachine extends BasePacket {
 
 		TileEntity ent = world.getTileEntity(new BlockPos(x, y, z));
 
-		if(ent != null && ent instanceof INetworkMachine) {
+		if(ent instanceof INetworkMachine) {
 			machine = (INetworkMachine)ent;
 			machine.readDataFromNetwork(in, packetId, nbt);
 		}
@@ -85,10 +85,10 @@ public class PacketMachine extends BasePacket {
 		BlockPos pos = new BlockPos(x,y,z);
 		Chunk chunk = world.getChunkFromBlockCoords(pos);
 
-		if(chunk != null && chunk.isLoaded()) {
+		if(chunk.isLoaded()) {
 			TileEntity ent = world.getTileEntity(pos);
 
-			if(ent != null && ent instanceof INetworkMachine) {
+			if(ent instanceof INetworkMachine) {
 				machine = (INetworkMachine)ent;
 				machine.readDataFromNetwork(in, packetId, nbt);
 			}

--- a/src/main/java/zmaster587/libVulpes/recipe/RecipeMachineFactory.java
+++ b/src/main/java/zmaster587/libVulpes/recipe/RecipeMachineFactory.java
@@ -24,10 +24,10 @@ public abstract class RecipeMachineFactory implements IRecipeFactory {
 	@Override
 	public IRecipe parse(JsonContext context, JsonObject json) {
 		
-		List<List<ItemStack>> inputs = new LinkedList<List<ItemStack>>();
-		List<ChanceItemStack> outputs = new LinkedList<ChanceItemStack>();
-		List<FluidStack> inputFluids = new LinkedList<FluidStack>();
-		List<ChanceFluidStack> outputFluids = new LinkedList<ChanceFluidStack>();
+		List<List<ItemStack>> inputs = new LinkedList<>();
+		List<ChanceItemStack> outputs = new LinkedList<>();
+		List<FluidStack> inputFluids = new LinkedList<>();
+		List<ChanceFluidStack> outputFluids = new LinkedList<>();
 		int timeTaken = 0;
 		int energy = 0;
 		int maxOutput = -1;
@@ -78,7 +78,7 @@ public abstract class RecipeMachineFactory implements IRecipeFactory {
 			throw new JsonParseException("Missing parameters");
 		}
 		
-		RecipesMachine.Recipe recipe = new RecipesMachine.Recipe(outputs, inputs, outputFluids, inputFluids, timeTaken, energy, new HashMap<Integer, String>());
+		RecipesMachine.Recipe recipe = new RecipesMachine.Recipe(outputs, inputs, outputFluids, inputFluids, timeTaken, energy, new HashMap<>());
 		
 		if(maxOutput > 0)
 			recipe.setMaxOutputSize(maxOutput);
@@ -97,7 +97,7 @@ public abstract class RecipeMachineFactory implements IRecipeFactory {
 		if(!json.isJsonArray())
 			return null;
 		
-		List<ChanceFluidStack> fluidstacks= new LinkedList<ChanceFluidStack>();
+		List<ChanceFluidStack> fluidstacks= new LinkedList<>();
 				
 		JsonArray ingredientListJSON =  json.getAsJsonArray();
 		for(JsonElement ingredient : ingredientListJSON)
@@ -128,10 +128,10 @@ public abstract class RecipeMachineFactory implements IRecipeFactory {
 			return null;
 		
 		JsonArray ingredientListJSON =  json.getAsJsonArray();
-		List<List<ItemStack>> inputs = new LinkedList<List<ItemStack>>();
+		List<List<ItemStack>> inputs = new LinkedList<>();
 		for(JsonElement ingredient : ingredientListJSON)
 		{
-			List<ItemStack> newList = new LinkedList<ItemStack>();
+			List<ItemStack> newList = new LinkedList<>();
 			for( ChanceItemStack stack3 : getIngredients(context, ingredient) )
 			{
 				newList.add(stack3.stack);
@@ -144,7 +144,7 @@ public abstract class RecipeMachineFactory implements IRecipeFactory {
 	
 	List<ChanceItemStack> getIngredients(JsonContext context, JsonElement json)
 	{
-		List<ChanceItemStack> stacks = new LinkedList<ChanceItemStack>();
+		List<ChanceItemStack> stacks = new LinkedList<>();
 		for(ItemStack stack : CraftingHelper.getIngredient(json, context).getMatchingStacks())
 		{
 			int count = stack.getCount();
@@ -177,7 +177,7 @@ public abstract class RecipeMachineFactory implements IRecipeFactory {
 		if(stacks.size() > 1)
 		{
 			ChanceItemStack stack  = stacks.get(0);
-			stacks = new LinkedList<ChanceItemStack>();
+			stacks = new LinkedList<>();
 			stacks.add(stack);
 		}
 		

--- a/src/main/java/zmaster587/libVulpes/render/RenderHelper.java
+++ b/src/main/java/zmaster587/libVulpes/render/RenderHelper.java
@@ -17,6 +17,8 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.opengl.GL11;
 
+import javax.annotation.Nonnull;
+
 @SideOnly(Side.CLIENT)
 public class RenderHelper {
 
@@ -211,10 +213,10 @@ public class RenderHelper {
 			buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
 			int j = fontrenderer.getStringWidth(displayString) / 2;
 			GlStateManager.color(0.0F, 0.0F, 0.0F, 0.25F);
-			buffer.pos((double)(-j - 1), (double)(-1 + b0), 0.0D).endVertex();
-			buffer.pos((double)(-j - 1), (double)(8 + b0), 0.0D).endVertex();
-			buffer.pos((double)(j + 1), (double)(8 + b0), 0.0D).endVertex();
-			buffer.pos((double)(j + 1), (double)(-1 + b0), 0.0D).endVertex();
+			buffer.pos(-j - 1, -1 + b0, 0.0D).endVertex();
+			buffer.pos(-j - 1, 8 + b0, 0.0D).endVertex();
+			buffer.pos(j + 1, 8 + b0, 0.0D).endVertex();
+			buffer.pos(j + 1, -1 + b0, 0.0D).endVertex();
 			tessellator.draw();
 			GlStateManager.enableTexture2D();
 			fontrenderer.drawString(displayString, -fontrenderer.getStringWidth(displayString) / 2, b0, 553648127);
@@ -447,9 +449,9 @@ public class RenderHelper {
 		renderBottomFace(buff, yMin, xMin, zMin, xMax, zMax);
 	}
 
-	public static void renderItem(TileEntity tile, ItemStack itemstack, RenderItem dummyItem)
+	public static void renderItem(TileEntity tile, @Nonnull ItemStack itemstack, RenderItem dummyItem)
 	{
-		if (itemstack != null)
+		if (!itemstack.isEmpty())
 		{
 			EntityItem entityitem = new EntityItem(tile.getWorld(), 0.0D, 0.0D, 0.0D, itemstack);
 			Item item = entityitem.getItem().getItem();

--- a/src/main/java/zmaster587/libVulpes/tile/IMultiblock.java
+++ b/src/main/java/zmaster587/libVulpes/tile/IMultiblock.java
@@ -5,13 +5,13 @@ import net.minecraft.util.math.BlockPos;
 
 public interface IMultiblock {
 	
-	public boolean hasMaster();
+	boolean hasMaster();
 	
-	public TileEntity getMasterBlock();
+	TileEntity getMasterBlock();
 	
-	public void setComplete(BlockPos pos);
+	void setComplete(BlockPos pos);
 	
-	public void setIncomplete();
+	void setIncomplete();
 	
-	public void setMasterBlock(BlockPos pos);
+	void setMasterBlock(BlockPos pos);
 }

--- a/src/main/java/zmaster587/libVulpes/tile/TileEntityForgeProducer.java
+++ b/src/main/java/zmaster587/libVulpes/tile/TileEntityForgeProducer.java
@@ -33,7 +33,7 @@ public abstract class TileEntityForgeProducer extends TileEntity implements IMod
 
 	@Override
 	public List<ModuleBase> getModules(int ID, EntityPlayer player) {
-		LinkedList<ModuleBase> modules = new LinkedList<ModuleBase>();
+		LinkedList<ModuleBase> modules = new LinkedList<>();
 		modules.add(new ModulePower(18, 20, energy));
 
 		return modules;
@@ -53,9 +53,7 @@ public abstract class TileEntityForgeProducer extends TileEntity implements IMod
 	@Override
 	public boolean hasCapability(Capability<?> capability, EnumFacing facing) {
 
-		if(capability == CapabilityEnergy.ENERGY || TeslaHandler.hasTeslaCapability(this, capability))
-			return true;
-		return false;
+		return capability == CapabilityEnergy.ENERGY || TeslaHandler.hasTeslaCapability(this, capability);
 	}
 
 	@Override
@@ -157,7 +155,7 @@ public abstract class TileEntityForgeProducer extends TileEntity implements IMod
 
 			if(tile != null && tile.hasCapability(CapabilityEnergy.ENERGY, facing.getOpposite())) {
 				IEnergyStorage storage = tile.getCapability(CapabilityEnergy.ENERGY,  facing.getOpposite());
-				if(storage.canReceive())
+				if(storage != null && storage.canReceive())
 					this.extractEnergy(storage.receiveEnergy(getUniversalEnergyStored(), false),false);
 			}
 		}

--- a/src/main/java/zmaster587/libVulpes/tile/TileEntityMachine.java
+++ b/src/main/java/zmaster587/libVulpes/tile/TileEntityMachine.java
@@ -14,6 +14,8 @@ import net.minecraft.world.World;
 import zmaster587.libVulpes.api.IToggleableMachine;
 import zmaster587.libVulpes.util.UniversalBattery;
 
+import javax.annotation.Nonnull;
+
 public abstract class TileEntityMachine extends TileEntity implements ISidedInventory, ITickable,  IToggleableMachine {
 	
 	
@@ -67,7 +69,7 @@ public abstract class TileEntityMachine extends TileEntity implements ISidedInve
 		{
 			ItemStack stack = inv[i];
 
-			if(stack != null) {
+			if(!stack.isEmpty()) {
 				NBTTagCompound tag = new NBTTagCompound();
 				tag.setByte("Slot", (byte)(i));
 				stack.writeToNBT(tag);
@@ -88,7 +90,7 @@ public abstract class TileEntityMachine extends TileEntity implements ISidedInve
 		
 		NBTTagList tagList = nbt.getTagList("Inventory", (byte)10);
 		for (int i = 0; i < tagList.tagCount(); i++) {
-			NBTTagCompound tag = (NBTTagCompound) tagList.getCompoundTagAt(i);
+			NBTTagCompound tag = tagList.getCompoundTagAt(i);
 			byte slot = tag.getByte("Slot");
 			if (slot >= 0 && slot < inv.length) {
 				inv[slot] = new ItemStack(tag);
@@ -105,31 +107,30 @@ public abstract class TileEntityMachine extends TileEntity implements ISidedInve
 	}
 	
 	@Override
+	@Nonnull
 	public ItemStack getStackInSlot(int i) {
 		return inv[i];
 	}
 	
 	public void incStackSize(int i, int amt) {
 
-		if(inv[i] == null)
-			return;
-		else if(inv[i].getCount() + amt > inv[i].getMaxStackSize())
-			inv[i].setCount(inv[i].getMaxStackSize());
-		else
-			inv[i].setCount(inv[i].getCount() + amt);
+		if(!inv[i].isEmpty()) {
+			inv[i].setCount(Math.min(inv[i].getCount() + amt, inv[i].getMaxStackSize()));
+		}
 	}
 	
 	@Override
+	@Nonnull
 	public ItemStack decrStackSize(int i, int j) {
 		ItemStack ret;
-		if(inv[i] == null)
-			ret = null;
+		if(inv[i].isEmpty())
+			ret = ItemStack.EMPTY;
 		else if(inv[i].getCount() > j) {
 			ret = inv[i].splitStack(j);
 		}
 		else {
 			ret = inv[i].copy();
-			inv[i] = null;
+			inv[i] = ItemStack.EMPTY;
 		}
 		return ret;
 	}
@@ -137,7 +138,7 @@ public abstract class TileEntityMachine extends TileEntity implements ISidedInve
 	public abstract void onInventoryUpdate();
 	
 	@Override
-	public void setInventorySlotContents(int i, ItemStack itemstack) {
+	public void setInventorySlotContents(int i, @Nonnull ItemStack itemstack) {
 		inv[i] = itemstack;
 
 		//if(!this.worldObj.isRemote)

--- a/src/main/java/zmaster587/libVulpes/tile/TileEntityPowerMachine.java
+++ b/src/main/java/zmaster587/libVulpes/tile/TileEntityPowerMachine.java
@@ -24,9 +24,7 @@ public abstract class TileEntityPowerMachine extends TileEntityMachine implement
 	@Override
 	public boolean hasCapability(Capability<?> capability, EnumFacing facing) {
 
-		if(capability == CapabilityEnergy.ENERGY || TeslaHandler.hasTeslaCapability(this, capability))
-			return true;
-		return false;
+		return capability == CapabilityEnergy.ENERGY || TeslaHandler.hasTeslaCapability(this, capability);
 	}
 
 	@Override

--- a/src/main/java/zmaster587/libVulpes/tile/TileEntityRFConsumer.java
+++ b/src/main/java/zmaster587/libVulpes/tile/TileEntityRFConsumer.java
@@ -52,9 +52,7 @@ public abstract class TileEntityRFConsumer extends TileEntity implements IPower,
 	@Override
 	public boolean hasCapability(Capability<?> capability, EnumFacing facing) {
 
-		if(capability == CapabilityEnergy.ENERGY || TeslaHandler.hasTeslaCapability(this, capability))
-			return true;
-		return false;
+		return capability == CapabilityEnergy.ENERGY || TeslaHandler.hasTeslaCapability(this, capability);
 	}
 
 	@Override

--- a/src/main/java/zmaster587/libVulpes/tile/TileInventoriedForgePowerMachine.java
+++ b/src/main/java/zmaster587/libVulpes/tile/TileInventoriedForgePowerMachine.java
@@ -37,7 +37,7 @@ public abstract class TileInventoriedForgePowerMachine extends TileInventoriedFo
 	protected void onOperationFinish() {
 		
 		setState(false);
-	};
+	}
 
 	@Override
 	public void update() {

--- a/src/main/java/zmaster587/libVulpes/tile/TileInventoriedForgeProducer.java
+++ b/src/main/java/zmaster587/libVulpes/tile/TileInventoriedForgeProducer.java
@@ -7,6 +7,9 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
 import zmaster587.libVulpes.util.EmbeddedInventory;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 public abstract class TileInventoriedForgeProducer extends TileEntityForgeProducer implements ISidedInventory {
 
 	protected EmbeddedInventory inventory;
@@ -25,7 +28,8 @@ public abstract class TileInventoriedForgeProducer extends TileEntityForgeProduc
 	}
 
 	@Override
-	public int[] getSlotsForFace(EnumFacing side) {
+	@Nonnull
+	public int[] getSlotsForFace(@Nullable EnumFacing side) {
 		int i[] = new int[inventory.getSizeInventory()];
 
 		for(int j = 0; j < i.length; j++) { i[j] = j;}
@@ -34,7 +38,7 @@ public abstract class TileInventoriedForgeProducer extends TileEntityForgeProduc
 	}
 
 	@Override
-	public boolean isItemValidForSlot(int index, ItemStack stack) {
+	public boolean isItemValidForSlot(int index, @Nonnull ItemStack stack) {
 		return true;
 	}
 
@@ -51,18 +55,20 @@ public abstract class TileInventoriedForgeProducer extends TileEntityForgeProduc
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack getStackInSlot(int slot) {
 		return inventory.getStackInSlot(slot);
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack decrStackSize(int slot, int amt) {
 		return inventory.decrStackSize(slot, amt);
 	}
 
 
 	@Override
-	public void setInventorySlotContents(int slot, ItemStack stack) {
+	public void setInventorySlotContents(int slot, @Nonnull ItemStack stack) {
 		inventory.setInventorySlotContents(slot, stack);
 	}
 
@@ -73,6 +79,7 @@ public abstract class TileInventoriedForgeProducer extends TileEntityForgeProduc
 	}
 
 	@Override
+	@Nullable
 	public String getName() {
 		return null;
 	}
@@ -103,18 +110,19 @@ public abstract class TileInventoriedForgeProducer extends TileEntityForgeProduc
 	}
 
 	@Override
-	public boolean canInsertItem(int index, ItemStack itemStackIn,
+	public boolean canInsertItem(int index, @Nonnull ItemStack itemStackIn,
 			EnumFacing direction) {
 		return inventory.canInsertItem(index, itemStackIn, direction);
 	}
 
 	@Override
-	public boolean canExtractItem(int index, ItemStack stack,
+	public boolean canExtractItem(int index, @Nonnull ItemStack stack,
 			EnumFacing direction) {
 		return inventory.canExtractItem(index, stack, direction);
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack removeStackFromSlot(int index) {
 		return inventory.removeStackFromSlot(index);
 	}

--- a/src/main/java/zmaster587/libVulpes/tile/TileInventoriedPointer.java
+++ b/src/main/java/zmaster587/libVulpes/tile/TileInventoriedPointer.java
@@ -7,43 +7,49 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 public class TileInventoriedPointer extends TilePointer implements IInventoryMultiblock, ISidedInventory {
 
 	@Override
 	public int getSizeInventory() {
 		TileEntity e = world.getTileEntity(masterBlockPos);
-		if(e != null && e instanceof IInventory)
+		if(e instanceof IInventory)
 			return ((IInventory)e).getSizeInventory();
 		return 0;
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack getStackInSlot(int i) {
 		TileEntity e = world.getTileEntity(masterBlockPos);
-		if(e != null && e instanceof IInventory)
+		if(e instanceof IInventory)
 			return ((IInventory)e).getStackInSlot(i);
-		return null;
+		return ItemStack.EMPTY;
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack decrStackSize(int i, int j) {
 		TileEntity e = world.getTileEntity(masterBlockPos);
-		if(e != null && e instanceof IInventory)
+		if(e instanceof IInventory)
 			return ((IInventory)e).decrStackSize(i,j);
-		return null;
+		return ItemStack.EMPTY;
 	}
 
 	@Override
-	public void setInventorySlotContents(int i, ItemStack itemstack) {
+	public void setInventorySlotContents(int i, @Nonnull ItemStack itemstack) {
 		TileEntity e = world.getTileEntity(masterBlockPos);
-		if(e != null && e instanceof IInventory)
+		if(e instanceof IInventory)
 			 ((IInventory)e).setInventorySlotContents(i,itemstack);
 	}
 
 	@Override
+	@Nullable
 	public String getName() {
 		TileEntity e = world.getTileEntity(masterBlockPos);
-		if(e != null && e instanceof IInventory)
+		if(e instanceof IInventory)
 			return ((IInventory)e).getName();
 		return null;
 	}
@@ -51,7 +57,7 @@ public class TileInventoriedPointer extends TilePointer implements IInventoryMul
 	@Override
 	public boolean hasCustomName() {
 		TileEntity e = world.getTileEntity(masterBlockPos);
-		if(e != null && e instanceof IInventory)
+		if(e instanceof IInventory)
 			return ((IInventory)e).hasCustomName();
 		return false;
 	}
@@ -59,15 +65,15 @@ public class TileInventoriedPointer extends TilePointer implements IInventoryMul
 	@Override
 	public int getInventoryStackLimit() {
 		TileEntity e = world.getTileEntity(masterBlockPos);
-		if(e != null && e instanceof IInventory)
+		if(e instanceof IInventory)
 			return ((IInventory)e).getInventoryStackLimit();
 		return 0;
 	}
 	
 	@Override
-	public boolean isUsableByPlayer(EntityPlayer entityplayer) {
+	public boolean isUsableByPlayer(@Nonnull EntityPlayer entityplayer) {
 		TileEntity e = world.getTileEntity(masterBlockPos);
-		if(e != null && e instanceof IInventory)
+		if(e instanceof IInventory)
 			return ((IInventory)e).isUsableByPlayer(entityplayer);
 		return false;
 	}
@@ -75,7 +81,7 @@ public class TileInventoriedPointer extends TilePointer implements IInventoryMul
 	@Override
 	public boolean isEmpty() {
 		TileEntity e = world.getTileEntity(masterBlockPos);
-		if(e != null && e instanceof IInventory)
+		if(e instanceof IInventory)
 			return ((IInventory)e).isEmpty();
 		return true;
 	}
@@ -83,33 +89,34 @@ public class TileInventoriedPointer extends TilePointer implements IInventoryMul
 	@Override
 	public void openInventory(EntityPlayer player) {
 		TileEntity e = world.getTileEntity(masterBlockPos);
-		if(e != null && e instanceof IInventory)
+		if(e instanceof IInventory)
 			((IInventory)e).openInventory(player);
 	}
 
 	@Override
 	public void closeInventory(EntityPlayer player) {
 		TileEntity e = world.getTileEntity(masterBlockPos);
-		if(e != null && e instanceof IInventory)
+		if(e instanceof IInventory)
 			((IInventory)e).closeInventory(player);
 	}
 
 	@Override
-	public boolean isItemValidForSlot(int i, ItemStack itemstack) {
+	public boolean isItemValidForSlot(int i, @Nonnull ItemStack itemstack) {
 		TileEntity e = world.getTileEntity(masterBlockPos);
-		if(e != null && e instanceof IInventory)
+		if(e instanceof IInventory)
 			return ((IInventory)e).isItemValidForSlot(i,itemstack);
 		return false;
 	}
 	
 	@Override
-	public int[] getSlotsForFace(EnumFacing side) {
+	@Nonnull
+	public int[] getSlotsForFace(@Nonnull EnumFacing side) {
 		TileEntity e = world.getTileEntity(masterBlockPos);
 		if(e != null && e instanceof ISidedInventory)
 			return ((ISidedInventory)e).getSlotsForFace(side);
 		else if(e != null && e instanceof ISidedInventory) {
 			int slots[] = new int[((IInventory)e).getSizeInventory()];
-			
+
 			for(int i = 0; i < slots.length; i++)
 			{
 				slots[i] = i;
@@ -120,29 +127,30 @@ public class TileInventoriedPointer extends TilePointer implements IInventoryMul
 	}
 	
 	@Override
-	public boolean canInsertItem(int i, ItemStack itemstack, EnumFacing direction) {
+	public boolean canInsertItem(int i, @Nonnull ItemStack itemstack, EnumFacing direction) {
 		TileEntity e = world.getTileEntity(masterBlockPos);
-		if(e != null && e instanceof ISidedInventory)
+		if(e instanceof ISidedInventory)
 			return ((ISidedInventory)e).canInsertItem(i,itemstack, direction);
 		return true;
 	}
 
 	@Override
-	public boolean canExtractItem(int i, ItemStack itemstack, EnumFacing direction) {
+	public boolean canExtractItem(int i, @Nonnull ItemStack itemstack, EnumFacing direction) {
 		TileEntity e = world.getTileEntity(masterBlockPos);
-		if(e != null && e instanceof ISidedInventory)
+		if(e instanceof ISidedInventory)
 			return ((ISidedInventory)e).canExtractItem(i,itemstack, direction);
 		
 		return true;
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack removeStackFromSlot(int index) {
 		TileEntity e = world.getTileEntity(masterBlockPos);
-		if(e != null && e instanceof ISidedInventory)
+		if(e instanceof ISidedInventory)
 			return ((ISidedInventory)e).removeStackFromSlot(index);
 		
-		return null;
+		return ItemStack.EMPTY;
 	}
 
 	@Override

--- a/src/main/java/zmaster587/libVulpes/tile/TileInventoriedRFConsumer.java
+++ b/src/main/java/zmaster587/libVulpes/tile/TileInventoriedRFConsumer.java
@@ -7,6 +7,9 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
 import zmaster587.libVulpes.util.EmbeddedInventory;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 public abstract class TileInventoriedRFConsumer extends TileEntityRFConsumer implements ISidedInventory {
 
 	protected EmbeddedInventory inventory;
@@ -37,18 +40,20 @@ public abstract class TileInventoriedRFConsumer extends TileEntityRFConsumer imp
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack getStackInSlot(int slot) {
 		return inventory.getStackInSlot(slot);
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack decrStackSize(int slot, int amt) {
 		return inventory.decrStackSize(slot, amt);
 	}
 
 
 	@Override
-	public void setInventorySlotContents(int slot, ItemStack stack) {
+	public void setInventorySlotContents(int slot, @Nonnull ItemStack stack) {
 		inventory.setInventorySlotContents(slot, stack);
 	}
 
@@ -59,6 +64,7 @@ public abstract class TileInventoriedRFConsumer extends TileEntityRFConsumer imp
 	}
 	
 	@Override
+	@Nullable
 	public String getName() {
 		return null;
 	}
@@ -83,18 +89,19 @@ public abstract class TileInventoriedRFConsumer extends TileEntityRFConsumer imp
 	}
 	
 	@Override
-	public boolean canInsertItem(int index, ItemStack itemStackIn,
+	public boolean canInsertItem(int index, @Nonnull ItemStack itemStackIn,
 			EnumFacing direction) {
 		return inventory.canInsertItem(index, itemStackIn, direction);
 	}
 
 	@Override
-	public boolean canExtractItem(int index, ItemStack stack,
+	public boolean canExtractItem(int index, @Nonnull ItemStack stack,
 			EnumFacing direction) {
 		return inventory.canExtractItem(index, stack, direction);
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack removeStackFromSlot(int index) {
 		return inventory.removeStackFromSlot(index);
 	}

--- a/src/main/java/zmaster587/libVulpes/tile/TilePointer.java
+++ b/src/main/java/zmaster587/libVulpes/tile/TilePointer.java
@@ -11,6 +11,8 @@ import net.minecraft.world.World;
 import zmaster587.libVulpes.LibVulpes;
 import zmaster587.libVulpes.interfaces.ILinkableTile;
 
+import javax.annotation.Nonnull;
+
 public class TilePointer extends TileEntity implements IMultiblock, ILinkableTile {
 	BlockPos masterBlockPos;
 
@@ -32,7 +34,7 @@ public class TilePointer extends TileEntity implements IMultiblock, ILinkableTil
 		return oldState.getBlock() != newState.getBlock();
 	}
 
-	public boolean onLinkStart(ItemStack item, TileEntity entity, EntityPlayer player, World world) {
+	public boolean onLinkStart(@Nonnull ItemStack item, TileEntity entity, EntityPlayer player, World world) {
 		if(hasMaster()) {
 			TileEntity master = this.getMasterBlock();
 			if(master instanceof ILinkableTile) {
@@ -41,7 +43,7 @@ public class TilePointer extends TileEntity implements IMultiblock, ILinkableTil
 		}
 		return false;
 	}
-	public boolean onLinkComplete(ItemStack item, TileEntity entity, EntityPlayer player, World world) {
+	public boolean onLinkComplete(@Nonnull ItemStack item, TileEntity entity, EntityPlayer player, World world) {
 		if(hasMaster()) {
 			TileEntity master = this.getMasterBlock();
 			if(master instanceof ILinkableTile) {

--- a/src/main/java/zmaster587/libVulpes/tile/TileSchematic.java
+++ b/src/main/java/zmaster587/libVulpes/tile/TileSchematic.java
@@ -16,10 +16,10 @@ public class TileSchematic extends TilePlaceholder implements ITickable {
 
 	private final int ttl = 6000;
 	private int timeAlive = 0;
-	List<BlockMeta> possibleBlocks;
+	private List<BlockMeta> possibleBlocks;
 
 	public TileSchematic() {
-		possibleBlocks = new ArrayList<BlockMeta>();
+		possibleBlocks = new ArrayList<>();
 	}
 
 	@Override
@@ -61,12 +61,12 @@ public class TileSchematic extends TilePlaceholder implements ITickable {
 		super.writeToNBT(nbt);
 		nbt.setInteger("timeAlive", timeAlive);
 
-		List<Integer> blockIds = new ArrayList<Integer>();
-		List<Integer> blockMetas = new ArrayList<Integer>();
-		for(int i = 0;  i < possibleBlocks.size();i++) {
-			blockIds.add(Block.getIdFromBlock(possibleBlocks.get(i).getBlock()));
-			blockMetas.add((int)possibleBlocks.get(i).getMeta());
-		}
+		List<Integer> blockIds = new ArrayList<>();
+		List<Integer> blockMetas = new ArrayList<>();
+        for (BlockMeta possibleBlock : possibleBlocks) {
+            blockIds.add(Block.getIdFromBlock(possibleBlock.getBlock()));
+            blockMetas.add((int) possibleBlock.getMeta());
+        }
 
 		if(!blockIds.isEmpty()) {
 			Integer[] bufferSpace1 = new Integer[blockIds.size()];

--- a/src/main/java/zmaster587/libVulpes/tile/energy/TileCoalGenerator.java
+++ b/src/main/java/zmaster587/libVulpes/tile/energy/TileCoalGenerator.java
@@ -10,6 +10,7 @@ import zmaster587.libVulpes.inventory.modules.ModuleSlotArray;
 import zmaster587.libVulpes.inventory.modules.ModuleText;
 import zmaster587.libVulpes.tile.TileInventoriedForgePowerMachine;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
 public class TileCoalGenerator extends TileInventoriedForgePowerMachine {
@@ -36,7 +37,7 @@ public class TileCoalGenerator extends TileInventoriedForgePowerMachine {
 	}
 
 	@Override
-	public void setInventorySlotContents(int slot, ItemStack stack) {
+	public void setInventorySlotContents(int slot, @Nonnull ItemStack stack) {
 		super.setInventorySlotContents(slot, stack);
 
 		if(!canGeneratePower())

--- a/src/main/java/zmaster587/libVulpes/tile/energy/TileCreativePowerInput.java
+++ b/src/main/java/zmaster587/libVulpes/tile/energy/TileCreativePowerInput.java
@@ -9,6 +9,8 @@ import net.minecraftforge.energy.IEnergyStorage;
 import zmaster587.libVulpes.energy.IPower;
 import zmaster587.libVulpes.util.CreativeBattery;
 
+import javax.annotation.Nullable;
+
 public class TileCreativePowerInput extends TilePlugBase implements IPower, ITickable {
 
 	public TileCreativePowerInput() {
@@ -63,6 +65,7 @@ public class TileCreativePowerInput extends TilePlugBase implements IPower, ITic
 	}
 
 	@Override
+	@Nullable
 	public String getName() {
 		// TODO Auto-generated method stub
 		return null;
@@ -70,7 +73,9 @@ public class TileCreativePowerInput extends TilePlugBase implements IPower, ITic
 
 	@Override
 	public int receiveEnergy(int amt, boolean simulate) {
-		return receiveEnergy(amt, simulate);
+		return 0;
+		// TODO why was this infinite recursion here?
+		//return receiveEnergy(amt, simulate);
 	}
 
 	@Override
@@ -92,7 +97,8 @@ public class TileCreativePowerInput extends TilePlugBase implements IPower, ITic
 
 				if(tile != null && tile.hasCapability(CapabilityEnergy.ENERGY, facing.getOpposite())) {
 					IEnergyStorage storage = tile.getCapability(CapabilityEnergy.ENERGY,  facing.getOpposite());
-					this.extractEnergy(storage.receiveEnergy(getUniversalEnergyStored(), false),false);
+					if(storage != null)
+						this.extractEnergy(storage.receiveEnergy(getUniversalEnergyStored(), false),false);
 				}
 			}
 		}

--- a/src/main/java/zmaster587/libVulpes/tile/energy/TileForgePowerOutput.java
+++ b/src/main/java/zmaster587/libVulpes/tile/energy/TileForgePowerOutput.java
@@ -6,6 +6,8 @@ import net.minecraft.util.ITickable;
 import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 
+import javax.annotation.Nullable;
+
 public class TileForgePowerOutput extends TilePlugBase implements IEnergyStorage, ITickable {
 
 	public TileForgePowerOutput() {
@@ -18,6 +20,7 @@ public class TileForgePowerOutput extends TilePlugBase implements IEnergyStorage
 	}
 
 	@Override
+	@Nullable
 	public String getName() {
 		return null;
 	}
@@ -50,7 +53,8 @@ public class TileForgePowerOutput extends TilePlugBase implements IEnergyStorage
 
 				if(tile != null && tile.hasCapability(CapabilityEnergy.ENERGY, facing.getOpposite())) {
 					IEnergyStorage storage = tile.getCapability(CapabilityEnergy.ENERGY,  facing.getOpposite());
-					this.extractEnergy(storage.receiveEnergy(getUniversalEnergyStored(), false),false);
+					if(storage != null)
+						this.extractEnergy(storage.receiveEnergy(getUniversalEnergyStored(), false),false);
 				}
 			}
 		}

--- a/src/main/java/zmaster587/libVulpes/tile/energy/TilePlugBase.java
+++ b/src/main/java/zmaster587/libVulpes/tile/energy/TilePlugBase.java
@@ -17,6 +17,8 @@ import zmaster587.libVulpes.tile.IMultiblock;
 import zmaster587.libVulpes.tile.TilePointer;
 import zmaster587.libVulpes.util.UniversalBattery;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -52,9 +54,7 @@ public abstract class TilePlugBase extends TilePointer implements IModularInvent
 	@Override
 	public boolean hasCapability(Capability<?> capability, EnumFacing facing) {
 
-		if(capability == CapabilityEnergy.ENERGY || TeslaHandler.hasTeslaCapability(this, capability))
-			return true;
-		return false;
+		return capability == CapabilityEnergy.ENERGY || TeslaHandler.hasTeslaCapability(this, capability);
 	}
 
 	@Override
@@ -111,17 +111,19 @@ public abstract class TilePlugBase extends TilePointer implements IModularInvent
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack getStackInSlot(int p_70301_1_) {
-		return null;
+		return ItemStack.EMPTY;
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack decrStackSize(int p_70298_1_, int p_70298_2_) {
-		return null;
+		return ItemStack.EMPTY;
 	}
 
 	@Override
-	public void setInventorySlotContents(int p_70299_1_, ItemStack p_70299_2_) {
+	public void setInventorySlotContents(int p_70299_1_, @Nonnull ItemStack p_70299_2_) {
 		
 	}
 
@@ -147,13 +149,14 @@ public abstract class TilePlugBase extends TilePointer implements IModularInvent
 	}
 
 	@Override
-	public boolean isItemValidForSlot(int slot, ItemStack stack) {
+	public boolean isItemValidForSlot(int slot, @Nonnull ItemStack stack) {
 		return true;
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack removeStackFromSlot(int index) {
-		return null;
+		return ItemStack.EMPTY;
 	}
 
 	@Override
@@ -178,7 +181,7 @@ public abstract class TilePlugBase extends TilePointer implements IModularInvent
 	
 	@Override
 	public List<ModuleBase> getModules(int ID, EntityPlayer player) {
-		List<ModuleBase> modules = new LinkedList<ModuleBase>();
+		List<ModuleBase> modules = new LinkedList<>();
 		modules.add(new ModulePower(18, 20,this));
 		return modules;
 	}
@@ -209,7 +212,7 @@ public abstract class TilePlugBase extends TilePointer implements IModularInvent
 	}
 
 	@Override
-	public boolean isUsableByPlayer(EntityPlayer player) {
+	public boolean isUsableByPlayer(@Nullable EntityPlayer player) {
 		return true;
 	}
 	

--- a/src/main/java/zmaster587/libVulpes/tile/energy/TilePlugInputGregTech.java
+++ b/src/main/java/zmaster587/libVulpes/tile/energy/TilePlugInputGregTech.java
@@ -7,6 +7,8 @@ import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import zmaster587.libVulpes.compat.GTEnergyCapability;
 
+import javax.annotation.Nullable;
+
 public class TilePlugInputGregTech extends TileForgePowerOutput {
 
 	public TilePlugInputGregTech() {
@@ -19,6 +21,7 @@ public class TilePlugInputGregTech extends TileForgePowerOutput {
 	}
 
 	@Override
+	@Nullable
 	public String getName() {
 		return null;
 	}
@@ -61,7 +64,8 @@ public class TilePlugInputGregTech extends TileForgePowerOutput {
 
 				if(tile != null && tile.hasCapability(CapabilityEnergy.ENERGY, facing.getOpposite())) {
 					IEnergyStorage storage = tile.getCapability(CapabilityEnergy.ENERGY,  facing.getOpposite());
-					this.extractEnergy(storage.receiveEnergy(getUniversalEnergyStored(), false),false);
+					if(storage != null)
+						this.extractEnergy(storage.receiveEnergy(getUniversalEnergyStored(), false),false);
 				}
 			}
 		}

--- a/src/main/java/zmaster587/libVulpes/tile/energy/TilePlugInputIC2.java
+++ b/src/main/java/zmaster587/libVulpes/tile/energy/TilePlugInputIC2.java
@@ -9,6 +9,8 @@ import net.minecraft.util.ITickable;
 import net.minecraftforge.common.MinecraftForge;
 import zmaster587.libVulpes.Configuration;
 
+import javax.annotation.Nullable;
+
 public class TilePlugInputIC2 extends TileForgePowerOutput implements IEnergySink, 
 ITickable {
 
@@ -49,6 +51,7 @@ ITickable {
 	}
 
 	@Override
+	@Nullable
 	public String getName() {
 		return null;
 	}

--- a/src/main/java/zmaster587/libVulpes/tile/energy/TilePlugInputRF.java
+++ b/src/main/java/zmaster587/libVulpes/tile/energy/TilePlugInputRF.java
@@ -4,6 +4,8 @@ import cofh.api.energy.IEnergyHandler;
 import zmaster587.libVulpes.util.UniversalBattery;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import javax.annotation.Nullable;
+
 public class TilePlugInputRF extends TilePlugBase implements IEnergyHandler {
 
 	UniversalBattery storage;
@@ -45,6 +47,7 @@ public class TilePlugInputRF extends TilePlugBase implements IEnergyHandler {
 	}
 	
 	@Override
+	@Nullable
 	public String getInventoryName() {
 		return null;
 	}

--- a/src/main/java/zmaster587/libVulpes/tile/energy/TilePowerOutput.java
+++ b/src/main/java/zmaster587/libVulpes/tile/energy/TilePowerOutput.java
@@ -5,6 +5,8 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ITickable;
 import zmaster587.libVulpes.energy.IPower;
 
+import javax.annotation.Nonnull;
+
 public class TilePowerOutput extends TilePlugBase implements IPower, ITickable {
 
 	public TilePowerOutput() {
@@ -32,7 +34,6 @@ public class TilePowerOutput extends TilePlugBase implements IPower, ITickable {
 
 				if(tile instanceof IPower) {
 					IPower handle = (IPower)tile;
-					storage.getUniversalEnergyStored();
 					storage.extractEnergy(handle.receiveEnergy(dir.getOpposite(), storage.getUniversalEnergyStored(), false), false);
 				}
 			}
@@ -71,6 +72,7 @@ public class TilePowerOutput extends TilePlugBase implements IPower, ITickable {
 	}
 
 	@Override
+	@Nonnull
 	public String getName() {
 		return getModularInventoryName();
 	}

--- a/src/main/java/zmaster587/libVulpes/tile/multiblock/TileMultiBlock.java
+++ b/src/main/java/zmaster587/libVulpes/tile/multiblock/TileMultiBlock.java
@@ -44,13 +44,13 @@ public class TileMultiBlock extends TileEntity {
 	protected boolean completeStructure, canRender;
 	protected byte timeAlive = 0;
 
-	protected LinkedList<IInventory> itemInPorts = new LinkedList<IInventory>();
-	protected LinkedList<IInventory> itemOutPorts = new LinkedList<IInventory>();
+	protected LinkedList<IInventory> itemInPorts = new LinkedList<>();
+	protected LinkedList<IInventory> itemOutPorts = new LinkedList<>();
 
-	protected LinkedList<IFluidHandlerInternal> fluidInPorts = new LinkedList<IFluidHandlerInternal>();
-	protected LinkedList<IFluidHandlerInternal> fluidOutPorts = new LinkedList<IFluidHandlerInternal>();
+	protected LinkedList<IFluidHandlerInternal> fluidInPorts = new LinkedList<>();
+	protected LinkedList<IFluidHandlerInternal> fluidOutPorts = new LinkedList<>();
 
-	protected static HashMap<Character, List<BlockMeta>> charMapping = new HashMap<Character, List<BlockMeta>>();
+	protected static HashMap<Character, List<BlockMeta>> charMapping = new HashMap<>();
 
 	public TileMultiBlock() {
 		completeStructure = false;
@@ -171,9 +171,7 @@ public class TileMultiBlock extends TileEntity {
 
 	/**
 	 * @param world world
-	 * @param destroyedX x coord of destroyed block
-	 * @param destroyedY y coord of destroyed block
-	 * @param destroyedZ z coord of destroyed block
+	 * @param destroyedPos coords of destroyed block
 	 * @param blockBroken set true if the block is being broken, otherwise some other means is being used to disassemble the machine
 	 */
 	public void deconstructMultiBlock(World world, BlockPos destroyedPos, boolean blockBroken, IBlockState state) {
@@ -222,9 +220,7 @@ public class TileMultiBlock extends TileEntity {
 	/**
 	 * Called when the multiblock is being deconstructed.  This is called for each block in the structure.
 	 * Provided in case of special handling
-	 * @param x
-	 * @param y
-	 * @param z
+	 * @param destroyedPos coords of destroyed block
 	 * @param block
 	 * @param tile
 	 */
@@ -277,7 +273,7 @@ public class TileMultiBlock extends TileEntity {
 	}
 
 	public List<BlockMeta> getAllowableWildCardBlocks() {
-		List<BlockMeta> list =new ArrayList<BlockMeta>();
+		List<BlockMeta> list = new ArrayList<>();
 		return list;
 	}
 
@@ -314,12 +310,12 @@ public class TileMultiBlock extends TileEntity {
 		Object[][][] structure = getStructure();
 
 		Vector3F<Integer> offset = getControllerOffset(structure);
-		List<BlockPos> replacableBlocks = new LinkedList<BlockPos>();
+		List<BlockPos> replacableBlocks = new LinkedList<>();
 
 		EnumFacing front = getFrontDirection(state);
 
 		//Store tile entities for later processing so we don't risk the check failing halfway through leaving half the multiblock assigned
-		LinkedList<TileEntity> tiles = new LinkedList<TileEntity>();
+		LinkedList<TileEntity> tiles = new LinkedList<>();
 
 		for(int y = 0; y < structure.length; y++) {
 			for(int z = 0; z < structure[0].length; z++) {
@@ -366,10 +362,10 @@ public class TileMultiBlock extends TileEntity {
 							continue;
 					}
 					//Make sure the structure is valid
-					if(!(structure[y][z][x] instanceof Character && (Character)structure[y][z][x] == 'c') && !(structure[y][z][x] instanceof Block && (Block)structure[y][z][x] == Blocks.AIR && world.isAirBlock(globalPos)) && !getAllowableBlocks(structure[y][z][x]).contains(new BlockMeta(block,meta))) {
+					if(!(structure[y][z][x] instanceof Character && (Character)structure[y][z][x] == 'c') && !(structure[y][z][x] instanceof Block && structure[y][z][x] == Blocks.AIR && world.isAirBlock(globalPos)) && !getAllowableBlocks(structure[y][z][x]).contains(new BlockMeta(block,meta))) {
 
 						//Can it be replaced?
-						if(block.isReplaceable(world, globalPos) && structure[y][z][x] instanceof Block && (Block)structure[y][z][x] == Blocks.AIR )
+						if(block.isReplaceable(world, globalPos) && structure[y][z][x] instanceof Block && structure[y][z][x] == Blocks.AIR )
 							replacableBlocks.add(globalPos);
 						else {
 							LibVulpes.proxy.spawnParticle("errorBox", world, globalX, globalY, globalZ, 0, 0, 0);
@@ -436,40 +432,38 @@ public class TileMultiBlock extends TileEntity {
 		if(input instanceof Character && (Character)input == '*') {
 			return getAllowableWildCardBlocks();
 		}
-		else if(input instanceof Character  && charMapping.containsKey((Character)input)) {
-			return charMapping.get((Character)input);
+		else if(input instanceof Character  && charMapping.containsKey(input)) {
+			return charMapping.get(input);
 		}
 		else if(input instanceof String) { //OreDict entry
 			List<ItemStack> stacks = OreDictionary.getOres((String)input);
-			List<BlockMeta> list = new LinkedList<BlockMeta>();
+			List<BlockMeta> list = new LinkedList<>();
 			for(ItemStack stack : stacks) {
 				//stack.get
 				Block block = Block.getBlockFromItem(stack.getItem());
-				if(block != null)
-					list.add(new BlockMeta(block, stack.getItem().getMetadata(stack.getItemDamage())));
+				list.add(new BlockMeta(block, stack.getItem().getMetadata(stack.getItemDamage())));
 			}
 			return list;
 		}
 		else if(input instanceof Block) {
-			List<BlockMeta> list = new ArrayList<BlockMeta>();
+			List<BlockMeta> list = new ArrayList<>();
 			list.add(new BlockMeta((Block) input, BlockMeta.WILDCARD));
 			return list;
 		}
 		else if(input instanceof BlockMeta) {
-			List<BlockMeta> list = new ArrayList<BlockMeta>();
+			List<BlockMeta> list = new ArrayList<>();
 			list.add((BlockMeta) input);
 			return list;
 		}
 		else if(input instanceof Block[]) {
-			List<BlockMeta> list = new ArrayList<BlockMeta>();
+			List<BlockMeta> list = new ArrayList<>();
 			for(Block b : (Block[])input) list.add(new BlockMeta(b));
 			return list;
 		}
 		else if(input instanceof List) {
 			return (List<BlockMeta>)input;
 		}
-		List<BlockMeta> list = new ArrayList<BlockMeta>();
-		return list;
+		return new ArrayList<>();
 	}
 
 	public boolean shouldHideBlock(World world, BlockPos pos, IBlockState tile) {
@@ -506,9 +500,9 @@ public class TileMultiBlock extends TileEntity {
 		else if(tile instanceof TileFluidHatch) {
 			TileFluidHatch liquidHatch = (TileFluidHatch)tile;
 			if(liquidHatch.isOutputOnly())
-				fluidOutPorts.add((IFluidHandlerInternal)liquidHatch);
+				fluidOutPorts.add(liquidHatch);
 			else
-				fluidInPorts.add((IFluidHandlerInternal)liquidHatch);
+				fluidInPorts.add(liquidHatch);
 		}
 	}
 
@@ -517,7 +511,7 @@ public class TileMultiBlock extends TileEntity {
 			for(int z = 0; z < structure[0].length; z++) {
 				for(int x = 0; x< structure[0][0].length; x++) {
 					if(structure[y][z][x] instanceof Character && (Character)structure[y][z][x] == 'c')
-						return new Vector3F<Integer>(x, y, z);
+						return new Vector3F<>(x, y, z);
 				}
 			}
 		}

--- a/src/main/java/zmaster587/libVulpes/tile/multiblock/TileMultiPowerConsumer.java
+++ b/src/main/java/zmaster587/libVulpes/tile/multiblock/TileMultiPowerConsumer.java
@@ -28,6 +28,7 @@ import zmaster587.libVulpes.util.INetworkMachine;
 import zmaster587.libVulpes.util.MultiBattery;
 import zmaster587.libVulpes.util.ZUtils;
 
+import javax.annotation.Nullable;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -41,7 +42,7 @@ public class TileMultiPowerConsumer extends TileMultiBlock implements INetworkMa
 	protected boolean enabled;
 	protected ModuleToggleSwitch toggleSwitch;
 	//On server determines change in power state, on client determines last power state on server
-	boolean hadPowerLastTick = true;
+	boolean hadPowerLastTick;
 
 	Object soundToPlay;
 
@@ -101,11 +102,11 @@ public class TileMultiPowerConsumer extends TileMultiBlock implements INetworkMa
 
 	/**
 	 * 
-	 * @param block
+	 * @param state
 	 * @param tile can be null
 	 * @return
 	 */
-	public float getTimeMultiplierForBlock(IBlockState state, TileEntity tile) {
+	public float getTimeMultiplierForBlock(IBlockState state, @Nullable TileEntity tile) {
 
 		ItemStack droppedItem = new ItemStack(state.getBlock(), 1, state.getBlock().getMetaFromState(state));
 
@@ -139,7 +140,7 @@ public class TileMultiPowerConsumer extends TileMultiBlock implements INetworkMa
 	@Override
 	public void update() {
 
-		//Freaky jenky crap to make sure the multiblock loads on chunkload etc
+		//Freaky janky crap to make sure the multiblock loads on chunkload etc
 		if(timeAlive == 0) {
 			if(!world.isRemote) {
 				if(isComplete())
@@ -147,7 +148,7 @@ public class TileMultiPowerConsumer extends TileMultiBlock implements INetworkMa
 			}
 			else {
 				SoundEvent str;
-				if(world.isRemote && (str = getSound()) != null) {
+				if((str = getSound()) != null) {
 					playMachineSound(str);
 				}
 			}
@@ -243,9 +244,7 @@ public class TileMultiPowerConsumer extends TileMultiBlock implements INetworkMa
 
 	/**
 	 * @param world world
-	 * @param destroyedX x coord of destroyed block
-	 * @param destroyedY y coord of destroyed block
-	 * @param destroyedZ z coord of destroyed block
+	 * @param destroyedPos coords of destroyed block
 	 * @param blockBroken set true if the block is being broken, otherwise some other means is being used to disassemble the machine
 	 */
 	@Override
@@ -361,7 +360,7 @@ public class TileMultiPowerConsumer extends TileMultiBlock implements INetworkMa
 
 	@Override
 	public List<ModuleBase> getModules(int ID, EntityPlayer player) {
-		LinkedList<ModuleBase> modules = new LinkedList<ModuleBase>();
+		LinkedList<ModuleBase> modules = new LinkedList<>();
 		modules.add(new ModulePower(18, 20, getBatteries()));
 		modules.add(toggleSwitch = new ModuleToggleSwitch(160, 5, 0, "", this,  zmaster587.libVulpes.inventory.TextureResources.buttonToggleImage, 11, 26, getMachineEnabled()));
 		modules.add(new ModuleText(140, 40, String.format("Speed:\n%.2fx", 1/getTimeMultiplier()), 0x2d2d2d));

--- a/src/main/java/zmaster587/libVulpes/tile/multiblock/TileMultiPowerProducer.java
+++ b/src/main/java/zmaster587/libVulpes/tile/multiblock/TileMultiPowerProducer.java
@@ -88,7 +88,7 @@ public class TileMultiPowerProducer extends TileMultiBlock implements IToggleBut
 
 	@Override
 	public List<ModuleBase> getModules(int ID, EntityPlayer player) {
-		LinkedList<ModuleBase> modules = new LinkedList<ModuleBase>();
+		LinkedList<ModuleBase> modules = new LinkedList<>();
 		modules.add(new ModulePower(18, 20, getBatteries()));
 		modules.add(toggleSwitch = new ModuleToggleSwitch(160, 5, 0, "", this,  zmaster587.libVulpes.inventory.TextureResources.buttonToggleImage, 11, 26, getMachineEnabled()));
 

--- a/src/main/java/zmaster587/libVulpes/tile/multiblock/hatch/TileFluidHatch.java
+++ b/src/main/java/zmaster587/libVulpes/tile/multiblock/hatch/TileFluidHatch.java
@@ -22,6 +22,8 @@ import zmaster587.libVulpes.util.FluidUtils;
 import zmaster587.libVulpes.util.IFluidHandlerInternal;
 import zmaster587.libVulpes.util.IconResource;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -152,7 +154,7 @@ public class TileFluidHatch extends TilePointer implements IFluidHandlerInternal
 
 	@Override
 	public List<ModuleBase> getModules(int ID, EntityPlayer player) {
-		List<ModuleBase> list = new ArrayList<ModuleBase>();
+		List<ModuleBase> list = new ArrayList<>();
 
 		list.add(new ModuleSlotArray(45, 18, this, 0, 1));
 		list.add(new ModuleSlotArray(45, 54, this, 1, 2));
@@ -179,17 +181,19 @@ public class TileFluidHatch extends TilePointer implements IFluidHandlerInternal
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack getStackInSlot(int slot) {
 		return inventory.getStackInSlot(slot);
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack decrStackSize(int slot, int amt) {
 		return inventory.decrStackSize(slot, amt);
 	}
 
 	@Override
-	public void setInventorySlotContents(int slot, ItemStack stack) {
+	public void setInventorySlotContents(int slot, @Nonnull ItemStack stack) {
 		inventory.setInventorySlotContents(slot, stack);
 		while(useBucket(0, getStackInSlot(0)));
 		
@@ -208,12 +212,12 @@ public class TileFluidHatch extends TilePointer implements IFluidHandlerInternal
 	}
 
 	@Override
-	public boolean isUsableByPlayer(EntityPlayer player) {
+	public boolean isUsableByPlayer(@Nullable EntityPlayer player) {
 		return true;
 	}
 
 	@Override
-	public boolean isItemValidForSlot(int slot, ItemStack stack) {
+	public boolean isItemValidForSlot(int slot, @Nonnull ItemStack stack) {
 		return inventory.isItemValidForSlot(slot, stack);
 	}
 
@@ -240,7 +244,7 @@ public class TileFluidHatch extends TilePointer implements IFluidHandlerInternal
 
 	//Yes i was lazy
 	//TODO: make better
-	protected boolean useBucket( int slot, ItemStack stack) {
+	protected boolean useBucket( int slot, @Nonnull ItemStack stack) {
 		return FluidUtils.attemptDrainContainerIInv(inventory, fluidTank, stack, 0, 1);
 	}
 
@@ -255,8 +259,9 @@ public class TileFluidHatch extends TilePointer implements IFluidHandlerInternal
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack removeStackFromSlot(int index) {
-		return null;
+		return ItemStack.EMPTY;
 	}
 
 	@Override
@@ -295,18 +300,19 @@ public class TileFluidHatch extends TilePointer implements IFluidHandlerInternal
 	}
 
 	@Override
+	@Nonnull
 	public int[] getSlotsForFace(EnumFacing side) {
 		return new int[] {0,1};
 	}
 
 	@Override
-	public boolean canInsertItem(int index, ItemStack itemStackIn,
+	public boolean canInsertItem(int index, @Nonnull ItemStack itemStackIn,
 			EnumFacing direction) {
 		return index == 0 && isItemValidForSlot(index, itemStackIn);
 	}
 
 	@Override
-	public boolean canExtractItem(int index, ItemStack stack,
+	public boolean canExtractItem(int index, @Nonnull ItemStack stack,
 			EnumFacing direction) {
 		return index == 1;
 	}

--- a/src/main/java/zmaster587/libVulpes/tile/multiblock/hatch/TileInventoryHatch.java
+++ b/src/main/java/zmaster587/libVulpes/tile/multiblock/hatch/TileInventoryHatch.java
@@ -16,6 +16,7 @@ import zmaster587.libVulpes.tile.TilePointer;
 import zmaster587.libVulpes.tile.multiblock.TileMultiBlock;
 import zmaster587.libVulpes.util.EmbeddedInventory;
 
+import javax.annotation.Nonnull;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -68,24 +69,26 @@ public class TileInventoryHatch extends TilePointer implements ISidedInventory, 
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack getStackInSlot(int slot) {
 		return inventory.getStackInSlot(slot);
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack decrStackSize(int slot, int amt) {
 		return inventory.decrStackSize(slot, amt);
 	}
 
 	@Override
-	public void setInventorySlotContents(int slot, ItemStack stack) {
+	public void setInventorySlotContents(int slot, @Nonnull ItemStack stack) {
 		setInventorySlotContentsNoUpdate(slot, stack);
 		if(this.hasMaster() && this.getMasterBlock() instanceof TileMultiBlock)
 			((TileMultiBlock)this.getMasterBlock()).onInventoryUpdated();
 	}
 
 
-	public void setInventorySlotContentsNoUpdate(int slot, ItemStack stack) {
+	public void setInventorySlotContentsNoUpdate(int slot, @Nonnull ItemStack stack) {
 		inventory.setInventorySlotContents(slot, stack);
 	}
 
@@ -119,30 +122,31 @@ public class TileInventoryHatch extends TilePointer implements ISidedInventory, 
 	}
 
 	@Override
-	public boolean isItemValidForSlot(int slot, ItemStack stack) {
+	public boolean isItemValidForSlot(int slot, @Nonnull ItemStack stack) {
 		return inventory.isItemValidForSlot(slot, stack);
 	}
 
 	@Override
+	@Nonnull
 	public int[] getSlotsForFace(EnumFacing side) {
 		return inventory.getSlotsForFace(side);
 	}
 
 	@Override
-	public boolean canInsertItem(int index, ItemStack itemStackIn,
+	public boolean canInsertItem(int index, @Nonnull ItemStack itemStackIn,
 			EnumFacing direction) {
 		return inventory.canInsertItem(index, itemStackIn, direction);
 	}
 
 	@Override
-	public boolean canExtractItem(int index, ItemStack stack,
+	public boolean canExtractItem(int index, @Nonnull ItemStack stack,
 			EnumFacing direction) {
 		return inventory.canExtractItem(index, stack, direction);
 	}
 
 	@Override
 	public List<ModuleBase> getModules(int ID, EntityPlayer player) {
-		LinkedList<ModuleBase> modules = new LinkedList<ModuleBase>();
+		LinkedList<ModuleBase> modules = new LinkedList<>();
 
 		modules.add(new ModuleSlotArray(8, 18, this, 0, this.getSizeInventory()));
 
@@ -150,6 +154,7 @@ public class TileInventoryHatch extends TilePointer implements ISidedInventory, 
 	}
 
 	@Override
+	@Nonnull
 	public String getName() {
 		return getModularInventoryName();
 	}
@@ -176,6 +181,7 @@ public class TileInventoryHatch extends TilePointer implements ISidedInventory, 
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack removeStackFromSlot(int index) {
 		return inventory.removeStackFromSlot(index);
 	}

--- a/src/main/java/zmaster587/libVulpes/tile/multiblock/hatch/TileOutputHatch.java
+++ b/src/main/java/zmaster587/libVulpes/tile/multiblock/hatch/TileOutputHatch.java
@@ -35,7 +35,7 @@ public class TileOutputHatch extends TileInventoryHatch {
 
 	@Override
 	public List<ModuleBase> getModules(int ID, EntityPlayer player) {
-		LinkedList<ModuleBase> modules = new LinkedList<ModuleBase>();
+		LinkedList<ModuleBase> modules = new LinkedList<>();
 		modules.add(new ModuleOutputSlotArray(8, 18, this, 0, this.getSizeInventory()));
 		return modules;
 	}

--- a/src/main/java/zmaster587/libVulpes/util/AdjacencyGraph.java
+++ b/src/main/java/zmaster587/libVulpes/util/AdjacencyGraph.java
@@ -6,7 +6,7 @@ public class AdjacencyGraph<T> {
 	private HashMap<T, HashSet<T>> adjacencyMatrix;
 
 	public AdjacencyGraph() {
-		adjacencyMatrix = new HashMap<T, HashSet<T>>();
+		adjacencyMatrix = new HashMap<>();
 	}
 
 	/**
@@ -17,11 +17,10 @@ public class AdjacencyGraph<T> {
 	public void add(T object, HashSet<T> adjNodes) {
 		if(!contains(object)) {
 			adjacencyMatrix.put(object, adjNodes);
-			Iterator<T> iterator = adjNodes.iterator();
 
-			while(iterator.hasNext()) {
-				adjacencyMatrix.get(iterator.next()).add(object);
-			}
+            for (T adjNode : adjNodes) {
+                adjacencyMatrix.get(adjNode).add(object);
+            }
 		}
 	}
 
@@ -62,7 +61,7 @@ public class AdjacencyGraph<T> {
 	 * @return a hashset containing all block connected to node including itself
 	 */
 	public HashSet<T> getAllNodesConnectedToNode(T node) {
-		HashSet<T> removableNodes = new HashSet<T>();
+		HashSet<T> removableNodes = new HashSet<>();
 		getAllNodesConnectedToBlock(node, removableNodes);
 
 		return removableNodes;
@@ -76,22 +75,19 @@ public class AdjacencyGraph<T> {
 	private void getAllNodesConnectedToBlock(T node,HashSet<T> removableNodes) {
 
 		
-		Stack<T> stack = new Stack<T>();
+		Stack<T> stack = new Stack<>();
 		stack.push(node);
 		removableNodes.add(node);
 		
 		while(!stack.isEmpty()) {
 			T stackElement = stack.pop();
-			Iterator<T> iterator = adjacencyMatrix.get(stackElement).iterator();
-			
-			while(iterator.hasNext()) {
-				T nextElement = iterator.next();
-				
-				if(!removableNodes.contains(nextElement)) {
-					stack.push(nextElement);
-					removableNodes.add(nextElement);
-				}
-			}
+
+            for (T nextElement : adjacencyMatrix.get(stackElement)) {
+                if (!removableNodes.contains(nextElement)) {
+                    stack.push(nextElement);
+                    removableNodes.add(nextElement);
+                }
+            }
 		}
 		
 		/*Iterator<T> iterator = adjacencyMatrix.get(node).iterator();
@@ -114,23 +110,20 @@ public class AdjacencyGraph<T> {
 	 */
 	private boolean findPathToBlock(T from, T to, HashSet<T> removableNodes) {
 
-		Stack<T> stack = new Stack<T>();
+		Stack<T> stack = new Stack<>();
 		stack.push(from);
 
 		while(!stack.isEmpty()) {
 			T stackElement = stack.pop();
 			removableNodes.add(stackElement);
-			Iterator<T> iterator = adjacencyMatrix.get(stackElement).iterator();
-			
-			while(iterator.hasNext()) {
-				T nextElement = iterator.next();
-				
-				if(to.equals(nextElement))
-					return true;
-				
-				if(!removableNodes.contains(nextElement))
-					stack.push(nextElement);
-			}
+
+            for (T nextElement : adjacencyMatrix.get(stackElement)) {
+                if (to.equals(nextElement))
+                    return true;
+
+                if (!removableNodes.contains(nextElement))
+                    stack.push(nextElement);
+            }
 		}
 		
 		return false;
@@ -143,7 +136,7 @@ public class AdjacencyGraph<T> {
 	 * @return true if a path from from to to is found
 	 */
 	public boolean doesPathExist(T from, T to) {
-		HashSet<T> pos = new HashSet<T>();
+		HashSet<T> pos = new HashSet<>();
 
 		return findPathToBlock(from, to, pos);
 	}
@@ -155,10 +148,8 @@ public class AdjacencyGraph<T> {
 	public Collection<T> removeAllNodesConnectedTo(T node) {
 
 		HashSet<T> removableNode = getAllNodesConnectedToNode(node);
-		Iterator<T> iterator = removableNode.iterator();
 
-		while(iterator.hasNext())
-			adjacencyMatrix.remove(iterator.next());
+        for (T t : removableNode) adjacencyMatrix.remove(t);
 		
 		return removableNode;
 	}
@@ -170,10 +161,9 @@ public class AdjacencyGraph<T> {
 	public void remove(T node) {
 		HashSet<T> set = adjacencyMatrix.get(node);
 		if(set != null) {
-			Iterator<T> iterator = set.iterator();
-			while(iterator.hasNext()) {
-				adjacencyMatrix.get(iterator.next()).remove(node);
-			}
+            for (T t : set) {
+                adjacencyMatrix.get(t).remove(node);
+            }
 		}
 		adjacencyMatrix.remove(node); //I will be not here
 	}

--- a/src/main/java/zmaster587/libVulpes/util/EmbeddedInventory.java
+++ b/src/main/java/zmaster587/libVulpes/util/EmbeddedInventory.java
@@ -8,21 +8,21 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
-import net.minecraftforge.common.util.Constants.NBT;
 import net.minecraftforge.items.ItemStackHandler;
 import zmaster587.libVulpes.interfaces.IInventoryUpdateCallback;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 
 public class EmbeddedInventory extends ItemStackHandler implements ISidedInventory {
 
-	ItemStackHandler handler;
+	private ItemStackHandler handler;
 
-	IInventoryUpdateCallback tile;
+	private IInventoryUpdateCallback tile;
 
-	NonNullList<Boolean> slotInsert;
-	NonNullList<Boolean> slotExtract;
+	private NonNullList<Boolean> slotInsert;
+	private NonNullList<Boolean> slotExtract;
 
 	public EmbeddedInventory(int size) {
 		this.stacks = NonNullList.withSize(size, ItemStack.EMPTY);
@@ -54,13 +54,13 @@ public class EmbeddedInventory extends ItemStackHandler implements ISidedInvento
 
 		nbt.setTag("outputItems", list);
 
-		ArrayList list2 = new ArrayList<Byte>();
+		ArrayList<Byte> list2 = new ArrayList<>();
 		for(int i = 0; i < this.slotInsert.size(); i++) {
 			list2.add(i, slotInsert.get(i) ? (byte)1 : (byte)0);
 		}
 		nbt.setTag("slotInsert", new NBTTagByteArray(list2));
 
-		ArrayList list3 = new ArrayList<Byte>();
+		ArrayList<Byte> list3 = new ArrayList<>();
 		for(int i = 0; i < this.slotExtract.size(); i++) {
 			list3.add(i, slotExtract.get(i) ? (byte)1 : (byte)0);
 		}
@@ -82,7 +82,7 @@ public class EmbeddedInventory extends ItemStackHandler implements ISidedInvento
 		this.stacks = NonNullList.withSize(Math.max(nbt.getInteger("size") == 0 ? 4 : nbt.getInteger("size"), this.stacks.size()), ItemStack.EMPTY);
 		handler = new ItemStackHandler(this.stacks);
 		for (int i = 0; i < list.tagCount(); i++) {
-			NBTTagCompound tag = (NBTTagCompound) list.getCompoundTagAt(i);
+			NBTTagCompound tag = list.getCompoundTagAt(i);
 			byte slot = tag.getByte("Slot");
 			if (slot >= 0 && slot < this.stacks.size()) {
 				this.stacks.set(slot, new ItemStack(tag));
@@ -93,12 +93,12 @@ public class EmbeddedInventory extends ItemStackHandler implements ISidedInvento
 		byte[] list2 = nbt.getByteArray("slotInsert");
 		this.slotInsert = NonNullList.withSize(list2.length, false);
 		for (int i = 0; i < list2.length; i++) {
-			this.slotInsert.set(i, (list2[i] == 1) ? true : false);
+			this.slotInsert.set(i, list2[i] == 1);
 		}
 		byte[] list3 = nbt.getByteArray("slotExtract");
 		this.slotExtract = NonNullList.withSize(list3.length, false);
 		for (int i = 0; i < list3.length; i++) {
-			this.slotExtract.set(i, (list3[i] == 1) ? true : false);
+			this.slotExtract.set(i, list3[i] == 1);
 		}
 
 		//Backcompat, to allow older worlds to load
@@ -116,6 +116,7 @@ public class EmbeddedInventory extends ItemStackHandler implements ISidedInvento
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack getStackInSlot(int slot) {
 		if(slot >= this.stacks.size())
 			return ItemStack.EMPTY;
@@ -124,6 +125,7 @@ public class EmbeddedInventory extends ItemStackHandler implements ISidedInvento
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack decrStackSize(int slot, int amt) {
 		ItemStack stack = this.stacks.get(slot);
 		if(!stack.isEmpty()) {
@@ -133,11 +135,11 @@ public class EmbeddedInventory extends ItemStackHandler implements ISidedInvento
 
 			return stack2;
 		}
-		return null;
+		return ItemStack.EMPTY;
 	}
 
 	@Override
-	public void setInventorySlotContents(int slot, ItemStack stack) {
+	public void setInventorySlotContents(int slot, @Nonnull ItemStack stack) {
 		this.stacks.set(slot, stack);
 	}
 
@@ -160,14 +162,14 @@ public class EmbeddedInventory extends ItemStackHandler implements ISidedInvento
 	}
 
 	@Override
-	public boolean isUsableByPlayer(EntityPlayer player) {
+	public boolean isUsableByPlayer(@Nullable EntityPlayer player) {
 		return true;
 	}
 
 	@Override
 	public boolean isEmpty() {
-		for(ItemStack i : this.stacks) {
-			if(i != null && !i.isEmpty())
+		for(ItemStack stack : this.stacks) {
+			if(!stack.isEmpty())
 				return false;
 		}
 		return true;
@@ -184,12 +186,13 @@ public class EmbeddedInventory extends ItemStackHandler implements ISidedInvento
 	}
 
 	@Override
-	public boolean isItemValidForSlot(int slot, ItemStack item) {
+	public boolean isItemValidForSlot(int slot, @Nonnull ItemStack item) {
 		return this.stacks.get(slot).isEmpty() || (this.stacks.get(slot).isItemEqual(item) && this.stacks.get(slot).getMaxStackSize() != this.stacks.get(slot).getCount());
 	}
 
 	@Override
-	public int[] getSlotsForFace(EnumFacing side) {
+	@Nonnull
+	public int[] getSlotsForFace(@Nullable EnumFacing side) {
 		int array[] = new int[this.stacks.size()];
 
 		for(int i = 0; i < this.stacks.size(); i++) {
@@ -200,31 +203,34 @@ public class EmbeddedInventory extends ItemStackHandler implements ISidedInvento
 
 
 
-	public boolean canInsertItem(int index, ItemStack itemStackIn, EnumFacing direction) {
+	public boolean canInsertItem(int index, @Nonnull ItemStack itemStackIn, @Nullable EnumFacing direction) {
 		return this.slotInsert.get(index);
 	}
 
 
-	public boolean canExtractItem(int index, ItemStack stack, EnumFacing direction) {
+	public boolean canExtractItem(int index, @Nonnull ItemStack stack, @Nullable EnumFacing direction) {
 		return this.slotExtract.get(index);
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
-		if (!slotInsert.isEmpty() && slotInsert.get(slot) == true ){
+		if (!slotInsert.isEmpty() && slotInsert.get(slot)){
 			return super.insertItem(slot, stack, simulate);
 		}
 		return stack;
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack extractItem(int slot, int amount, boolean simulate) {
-		if (!slotExtract.isEmpty() && slotExtract.get(slot) == true ){
+		if (!slotExtract.isEmpty() && slotExtract.get(slot)){
 			return super.extractItem(slot, amount, simulate);
 		}
 		return ItemStack.EMPTY;
 	}
 
+	@Nonnull
 	public String getName() {
 		return "";
 	}
@@ -234,6 +240,7 @@ public class EmbeddedInventory extends ItemStackHandler implements ISidedInvento
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack removeStackFromSlot(int index) {
 		ItemStack stack = this.stacks.get(index);
 		this.stacks.set(index, ItemStack.EMPTY);
@@ -261,6 +268,7 @@ public class EmbeddedInventory extends ItemStackHandler implements ISidedInvento
 	}
 
 	@Override
+	@Nonnull
 	public ITextComponent getDisplayName() {
 		return new TextComponentString("Inventory");
 	}

--- a/src/main/java/zmaster587/libVulpes/util/FluidUtils.java
+++ b/src/main/java/zmaster587/libVulpes/util/FluidUtils.java
@@ -11,6 +11,7 @@ import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import zmaster587.libVulpes.event.BucketHandler;
 
+import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -18,43 +19,48 @@ import java.util.Map;
 
 public class FluidUtils {
 	
-	private static Map<String, List<String>> fluidEquivilentMapping = new HashMap<String, List<String>>();
+	private static Map<String, List<String>> fluidEquivalentMapping = new HashMap<>();
 
-	public static boolean containsFluid(ItemStack stack) {
+	public static boolean containsFluid(@Nonnull ItemStack stack) {
 		return !stack.isEmpty() && stack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, EnumFacing.UP);
 	}
 
-	public static boolean containsFluid(ItemStack stack, Fluid fluid) {
+	public static boolean containsFluid(@Nonnull ItemStack stack, Fluid fluid) {
 		if(containsFluid(stack)) {
 			IFluidHandlerItem fluidItem = stack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, EnumFacing.UP);
-			FluidStack fluidStack = fluidItem.getTankProperties()[0].getContents();
-			if(fluidStack != null && areFluidsSameType(fluidStack.getFluid(), fluid))
-				return true;
+
+			if(fluidItem != null) {
+				FluidStack fluidStack = fluidItem.getTankProperties()[0].getContents();
+				return fluidStack != null && areFluidsSameType(fluidStack.getFluid(), fluid);
+			}
 		}
 
 		return false;
 	}
 
-	public static int getFluidItemCapacity(ItemStack stack) {
+	public static int getFluidItemCapacity(@Nonnull ItemStack stack) {
 		if(containsFluid(stack)) {
 			IFluidHandlerItem fluidItem = stack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, EnumFacing.UP);
-			return  fluidItem.getTankProperties()[0].getCapacity();
+
+			if(fluidItem != null)
+				return  fluidItem.getTankProperties()[0].getCapacity();
 		}
 		return 0;
 	}
 
-	public static IFluidHandlerItem getFluidHandler(ItemStack stack) {
+	public static IFluidHandlerItem getFluidHandler(@Nonnull ItemStack stack) {
 		return stack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, EnumFacing.UP);
 	}
 
-	public static FluidStack getFluidForItem(ItemStack item) {
+	public static FluidStack getFluidForItem(@Nonnull ItemStack item) {
 		if(!containsFluid(item))
 			return null;
 		IFluidHandlerItem fluidItem = item.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, EnumFacing.UP);
-		return fluidItem.getTankProperties()[0].getContents();
+
+		return fluidItem == null ? null : fluidItem.getTankProperties()[0].getContents();
 	}
 
-	public static boolean attemptDrainContainerIInv(EmbeddedInventory inv, IFluidTank tank, ItemStack stack, int inputSlot, int outputSlot) {
+	public static boolean attemptDrainContainerIInv(EmbeddedInventory inv, IFluidTank tank, @Nonnull ItemStack stack, int inputSlot, int outputSlot) {
 
 		if(containsFluid(stack)) {
 			
@@ -147,15 +153,14 @@ public class FluidUtils {
 	
 	private static void addFluidMapping(String in, String altName)
 	{
-		String fluidKeyName = in;
 		List<String> mappedValues;
-		if(!fluidEquivilentMapping.containsKey(fluidKeyName))
+		if(!fluidEquivalentMapping.containsKey(in))
 		{
-			mappedValues = new LinkedList<String>();
-			fluidEquivilentMapping.put(fluidKeyName, mappedValues);
+			mappedValues = new LinkedList<>();
+			fluidEquivalentMapping.put(in, mappedValues);
 		}
 		else
-			mappedValues = fluidEquivilentMapping.get(fluidKeyName);
+			mappedValues = fluidEquivalentMapping.get(in);
 		
 		mappedValues.add(altName);
 	}
@@ -169,6 +174,6 @@ public class FluidUtils {
 		if(inFluidName.equals(otherFluidName))
 			return true;
 		
-		return fluidEquivilentMapping.containsKey(inFluidName) && fluidEquivilentMapping.get(inFluidName).contains(otherFluidName);
+		return fluidEquivalentMapping.containsKey(inFluidName) && fluidEquivalentMapping.get(inFluidName).contains(otherFluidName);
 	}
 }

--- a/src/main/java/zmaster587/libVulpes/util/IAdjBlockUpdate.java
+++ b/src/main/java/zmaster587/libVulpes/util/IAdjBlockUpdate.java
@@ -4,5 +4,5 @@ public interface IAdjBlockUpdate {
 	/**
 	 * Called when an adjacent block is updated
 	 */
-	public void onAdjacentBlockUpdated();
+	void onAdjacentBlockUpdated();
 }

--- a/src/main/java/zmaster587/libVulpes/util/IFluidHandlerInternal.java
+++ b/src/main/java/zmaster587/libVulpes/util/IFluidHandlerInternal.java
@@ -4,9 +4,9 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
 public interface IFluidHandlerInternal extends IFluidHandler {
-	public int fillInternal(FluidStack resource, boolean doDrain);
+	int fillInternal(FluidStack resource, boolean doDrain);
 	
-	public FluidStack drainInternal(int maxDrain, boolean doDrain);
+	FluidStack drainInternal(int maxDrain, boolean doDrain);
 	
-	public FluidStack drainInternal(FluidStack maxDrain, boolean doDrain);
+	FluidStack drainInternal(FluidStack maxDrain, boolean doDrain);
 }

--- a/src/main/java/zmaster587/libVulpes/util/INetworkMachine.java
+++ b/src/main/java/zmaster587/libVulpes/util/INetworkMachine.java
@@ -9,11 +9,11 @@ import net.minecraftforge.fml.relauncher.Side;
 public interface INetworkMachine {
 	
 	//Writes data to the network given an id of what type of packet to write
-	public void writeDataToNetwork(ByteBuf out, byte id);
+	void writeDataToNetwork(ByteBuf out, byte id);
 	
 	//Reads data, stores read data to nbt to be passed to useNetworkData
-	public void readDataFromNetwork(ByteBuf in, byte packetId, NBTTagCompound nbt);
+	void readDataFromNetwork(ByteBuf in, byte packetId, NBTTagCompound nbt);
 	
 	//Applies changes from network
-	public void useNetworkData(EntityPlayer player, Side side, byte id, NBTTagCompound nbt);
+	void useNetworkData(EntityPlayer player, Side side, byte id, NBTTagCompound nbt);
 }

--- a/src/main/java/zmaster587/libVulpes/util/InputSyncHandler.java
+++ b/src/main/java/zmaster587/libVulpes/util/InputSyncHandler.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 
 public class InputSyncHandler {
 
-	public static HashMap<EntityPlayer, Boolean> spaceDown = new HashMap<EntityPlayer, Boolean>();
+	public static HashMap<EntityPlayer, Boolean> spaceDown = new HashMap<>();
 	
 
 	public static boolean isSpaceDown(EntityPlayer player) {
@@ -29,7 +29,7 @@ public class InputSyncHandler {
 		case 0:
 			
 			stack = player.inventory.armorInventory.get(2);
-			if(stack != null) {
+			if(!stack.isEmpty()) {
 				IJetPack pack;
 				if(stack.getItem() instanceof IJetPack) {
 					pack = ((IJetPack)stack.getItem());
@@ -39,7 +39,7 @@ public class InputSyncHandler {
 					IInventory inv = ((IModularArmor)stack.getItem()).loadModuleInventory(stack);
 					
 					for(int i = 0; i < inv.getSizeInventory(); i++) {
-						if(inv.getStackInSlot(i) != null && inv.getStackInSlot(i).getItem() instanceof IJetPack) {
+						if(!inv.getStackInSlot(i).isEmpty() && inv.getStackInSlot(i).getItem() instanceof IJetPack) {
 							pack = ((IJetPack)inv.getStackInSlot(i).getItem());
 							pack.setEnabledState(inv.getStackInSlot(i), !pack.isEnabled(inv.getStackInSlot(i)));
 						}
@@ -52,7 +52,7 @@ public class InputSyncHandler {
 			
 		case 1:
 			stack = player.inventory.armorInventory.get(2);
-			if(stack != null) {
+			if(!stack.isEmpty()) {
 				IJetPack pack;
 				if(stack.getItem() instanceof IJetPack) {
 					pack = ((IJetPack)stack.getItem());
@@ -62,7 +62,7 @@ public class InputSyncHandler {
 					IInventory inv = ((IModularArmor)stack.getItem()).loadModuleInventory(stack);
 					
 					for(int i = 0; i < inv.getSizeInventory(); i++) {
-						if(inv.getStackInSlot(i) != null && inv.getStackInSlot(i).getItem() instanceof IJetPack) {
+						if(!inv.getStackInSlot(i).isEmpty() && inv.getStackInSlot(i).getItem() instanceof IJetPack) {
 							pack = ((IJetPack)inv.getStackInSlot(i).getItem());
 							pack.changeMode(inv.getStackInSlot(i), inv, player);
 						}

--- a/src/main/java/zmaster587/libVulpes/util/ItemStackMapping.java
+++ b/src/main/java/zmaster587/libVulpes/util/ItemStackMapping.java
@@ -2,9 +2,11 @@ package zmaster587.libVulpes.util;
 
 import net.minecraft.item.ItemStack;
 
+import javax.annotation.Nonnull;
+
 public class ItemStackMapping {
-	ItemStack stack;
-	public ItemStackMapping(ItemStack stack) {
+	private ItemStack stack;
+	public ItemStackMapping(@Nonnull ItemStack stack) {
 		this.stack = stack;
 	}
 

--- a/src/main/java/zmaster587/libVulpes/util/MultiBattery.java
+++ b/src/main/java/zmaster587/libVulpes/util/MultiBattery.java
@@ -8,7 +8,7 @@ public class MultiBattery implements IUniversalEnergy {
 
 	//Note: as of writing there should never be a need to save this
 	
-	protected LinkedList<IUniversalEnergy> batteries = new LinkedList<IUniversalEnergy>();
+	protected LinkedList<IUniversalEnergy> batteries = new LinkedList<>();
 	
 	public void addBattery(IUniversalEnergy battery) {
 		batteries.add(battery);

--- a/src/main/java/zmaster587/libVulpes/util/MultiInventory.java
+++ b/src/main/java/zmaster587/libVulpes/util/MultiInventory.java
@@ -5,6 +5,8 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.ITextComponent;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 
 public class MultiInventory implements IInventory {
@@ -25,6 +27,7 @@ public class MultiInventory implements IInventory {
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack getStackInSlot(int i) {
 		for(IInventory inv : inventories) {
 			if(i >= inv.getSizeInventory()) {
@@ -33,10 +36,11 @@ public class MultiInventory implements IInventory {
 			}
 			return inv.getStackInSlot(i);
 		}
-		return null;
+		return ItemStack.EMPTY;
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack decrStackSize(int i, int j) {
 		
 		for(IInventory inv : inventories) {
@@ -46,12 +50,12 @@ public class MultiInventory implements IInventory {
 			}
 			return inv.decrStackSize(i, j);
 		}
-		return null;
+		return ItemStack.EMPTY;
 	}
 
 
 	@Override
-	public void setInventorySlotContents(int i, ItemStack j) {
+	public void setInventorySlotContents(int i, @Nonnull ItemStack j) {
 		for(IInventory inv : inventories) {
 			if(i >= inv.getSizeInventory()) {
 				i -= inv.getSizeInventory();
@@ -73,7 +77,7 @@ public class MultiInventory implements IInventory {
 	}
 
 	@Override
-	public boolean isUsableByPlayer(EntityPlayer p_70300_1_) {
+	public boolean isUsableByPlayer(@Nullable EntityPlayer p_70300_1_) {
 		return true;
 	}
 	
@@ -87,7 +91,7 @@ public class MultiInventory implements IInventory {
 	}
 
 	@Override
-	public boolean isItemValidForSlot(int i, ItemStack j) {
+	public boolean isItemValidForSlot(int i, @Nonnull ItemStack j) {
 		
 		for(IInventory inv : inventories) {
 			if(i >= inv.getSizeInventory()) {
@@ -101,6 +105,7 @@ public class MultiInventory implements IInventory {
 	}
 
 	@Override
+	@Nullable
 	public String getName() {
 		return null;
 	}
@@ -111,11 +116,13 @@ public class MultiInventory implements IInventory {
 	}
 
 	@Override
+	@Nullable
 	public ITextComponent getDisplayName() {
 		return null;
 	}
 
 	@Override
+	@Nonnull
 	public ItemStack removeStackFromSlot(int index) {
 		for(IInventory inv : inventories) {
 			if(index >= inv.getSizeInventory()) {
@@ -125,7 +132,7 @@ public class MultiInventory implements IInventory {
 			return inv.removeStackFromSlot(index);
 			
 		}
-		return null;
+		return ItemStack.EMPTY;
 	}
 
 	@Override

--- a/src/main/java/zmaster587/libVulpes/util/OreProductColorizer.java
+++ b/src/main/java/zmaster587/libVulpes/util/OreProductColorizer.java
@@ -11,9 +11,11 @@ import zmaster587.libVulpes.api.material.Material;
 import zmaster587.libVulpes.block.BlockOre;
 import zmaster587.libVulpes.items.ItemOreProduct;
 
+import javax.annotation.Nonnull;
+
 public class OreProductColorizer   implements IItemColor, IBlockColor  {
 	@Override
-	public int getColorFromItemstack(ItemStack stack, int tintIndex) {
+	public int getColorFromItemstack(@Nonnull ItemStack stack, int tintIndex) {
 		if(stack.getItem() instanceof ItemOreProduct)
 			return ((ItemOreProduct)stack.getItem()).properties.get(stack.getMetadata()).getColor();
 		else 
@@ -35,7 +37,7 @@ public class OreProductColorizer   implements IItemColor, IBlockColor  {
 	}
 
 	/*@Override
-	public int getColorFromItemstack(ItemStack stack, int tintIndex) {
+	public int getColorFromItemstack(@Nonnull ItemStack stack, int tintIndex) {
 		return ((BlockOre)Block.getBlockFromItem(stack.getItem())).ores[stack.getMetadata()].getColor();
 	}*/
 }

--- a/src/main/java/zmaster587/libVulpes/util/PoweredTimedItemStack.java
+++ b/src/main/java/zmaster587/libVulpes/util/PoweredTimedItemStack.java
@@ -2,15 +2,18 @@ package zmaster587.libVulpes.util;
 
 import net.minecraft.item.ItemStack;
 
+import javax.annotation.Nonnull;
+
 public class PoweredTimedItemStack {
 	ItemStack storedItem;
 	int storedPower, storedTime;
-	public PoweredTimedItemStack(ItemStack item, int power, int time) {
+	public PoweredTimedItemStack(@Nonnull ItemStack item, int power, int time) {
 		storedItem = item;
 		storedPower = power;
 		storedTime = time;
 	}
-	
+
+	@Nonnull
 	public ItemStack getItemStack() { return storedItem; }
 	public int getTime() { return storedTime;}
 	public int getPower() { return storedPower; }

--- a/src/main/java/zmaster587/libVulpes/util/XMLRecipeLoader.java
+++ b/src/main/java/zmaster587/libVulpes/util/XMLRecipeLoader.java
@@ -104,7 +104,7 @@ public class XMLRecipeLoader {
 					continue;
 				}
 
-				List<Object> inputList = new LinkedList<Object>();
+				List<Object> inputList = new LinkedList<>();
 
 				for(int i = 0; i < inputNode.getChildNodes().getLength(); i++) {
 					Node node = inputNode.getChildNodes().item(i);
@@ -118,7 +118,7 @@ public class XMLRecipeLoader {
 						inputList.add(obj);
 				}
 
-				List<Object> outputList = new LinkedList<Object>();
+				List<Object> outputList = new LinkedList<>();
 
 				for(int i = 0; i < outputNode.getChildNodes().getLength(); i++) {
 					Node node = outputNode.getChildNodes().item(i);
@@ -173,89 +173,95 @@ public class XMLRecipeLoader {
 	}
 
 	public Object parseItemType(Node node, boolean output) {
-		if(node.getNodeName().equals("itemStack")) {
-			String text = node.getTextContent();
-			//Backwards compat, " " used to be the delimiter
-			String[] splitStr = text.contains(";") ? text.split(";") : text.split(" ");
-			String name = splitStr[0].trim();
-			
-			int meta = 0;
-			int size = 1;
-			//format: "name meta size"
-			if(splitStr.length > 1) {
-				try {
-					size = Integer.parseInt(splitStr[1].trim());
-				} catch( NumberFormatException e) {}
-			}
-			if(splitStr.length > 2) {
-				try {
-					meta= Integer.parseInt(splitStr[2].trim());
-				} catch (NumberFormatException e) {}
-			}
+		switch (node.getNodeName()) {
+			case "itemStack": {
+				String text = node.getTextContent();
+				//Backwards compat, " " used to be the delimiter
+				String[] splitStr = text.contains(";") ? text.split(";") : text.split(" ");
+				String name = splitStr[0].trim();
 
-			ItemStack stack = null;
-			Block block = Block.getBlockFromName(name);
-			if(block == null) {
-				Item item = Item.getByNameOrId(name);
-				if(item != null)
-					stack = new ItemStack(item, size, meta);
-			}
-			else
-				stack = new ItemStack(block, size, meta);
-
-			return stack;
-		}
-		else if(node.getNodeName().equals("oreDict")) {
-			
-			String text = node.getTextContent();
-			//Backwards compat, " " used to be the delimiter
-			String[] splitStr = text.contains(";") ? text.split(";") : text.split(" ");
-			String name = splitStr[0].trim();
-			if(OreDictionary.doesOreNameExist(name)) {
-
-				
-				Object ret = name;
-				int number = 1;
-				if(splitStr.length > 1) {
-
+				int meta = 0;
+				int size = 1;
+				//format: "name meta size"
+				if (splitStr.length > 1) {
 					try {
-						number = Integer.parseInt(splitStr[1].trim());
-					} catch (NumberFormatException e) {}
+						size = Integer.parseInt(splitStr[1].trim());
+					} catch (NumberFormatException e) {
+					}
+				}
+				if (splitStr.length > 2) {
+					try {
+						meta = Integer.parseInt(splitStr[2].trim());
+					} catch (NumberFormatException e) {
+					}
 				}
 
-				if(splitStr.length >= 1) {
-					if(output) {
-						List<ItemStack> list = OreDictionary.getOres(name);
-						if(!list.isEmpty()) {
-							ItemStack oreDict = OreDictionary.getOres(name).get(0);
-							ret = new ItemStack(oreDict.getItem(), number, oreDict.getMetadata());
+				ItemStack stack = ItemStack.EMPTY;
+				Block block = Block.getBlockFromName(name);
+				if (block == null) {
+					Item item = Item.getByNameOrId(name);
+					if (item != null)
+						stack = new ItemStack(item, size, meta);
+				} else
+					stack = new ItemStack(block, size, meta);
+
+				return stack;
+			}
+			case "oreDict": {
+
+				String text = node.getTextContent();
+				//Backwards compat, " " used to be the delimiter
+				String[] splitStr = text.contains(";") ? text.split(";") : text.split(" ");
+				String name = splitStr[0].trim();
+				if (OreDictionary.doesOreNameExist(name)) {
+
+
+					Object ret = name;
+					int number = 1;
+					if (splitStr.length > 1) {
+
+						try {
+							number = Integer.parseInt(splitStr[1].trim());
+						} catch (NumberFormatException e) {
 						}
 					}
-					else
-						ret = new NumberedOreDictStack(name, number);
-				}
 
-				return ret;
+					if (splitStr.length >= 1) {
+						if (output) {
+							List<ItemStack> list = OreDictionary.getOres(name);
+							if (!list.isEmpty()) {
+								ItemStack oreDict = OreDictionary.getOres(name).get(0);
+								ret = new ItemStack(oreDict.getItem(), number, oreDict.getMetadata());
+							}
+						} else
+							ret = new NumberedOreDictStack(name, number);
+					}
+
+					return ret;
+				}
+				break;
 			}
-		}
-		else if(node.getNodeName().equals("fluidStack")) {
-			
-			String text = node.getTextContent();
-			String splitStr[];
-			
-			//Backwards compat, " " used to be the delimiter
-			splitStr = text.contains(";") ? text.split(";") : text.split(" ");
-			
-			Fluid fluid;
-			if((fluid = FluidRegistry.getFluid(splitStr[0].trim())) != null) {
-				int amount = 1000;
-				if(splitStr.length > 1) {
-					try {
-						amount = Integer.parseInt(splitStr[1].trim());
-					} catch (NumberFormatException e) {}
-				}
+			case "fluidStack": {
 
-				return new FluidStack(fluid, amount);
+				String text = node.getTextContent();
+				String splitStr[];
+
+				//Backwards compat, " " used to be the delimiter
+				splitStr = text.contains(";") ? text.split(";") : text.split(" ");
+
+				Fluid fluid;
+				if ((fluid = FluidRegistry.getFluid(splitStr[0].trim())) != null) {
+					int amount = 1000;
+					if (splitStr.length > 1) {
+						try {
+							amount = Integer.parseInt(splitStr[1].trim());
+						} catch (NumberFormatException e) {
+						}
+					}
+
+					return new FluidStack(fluid, amount);
+				}
+				break;
 			}
 		}
 
@@ -264,35 +270,35 @@ public class XMLRecipeLoader {
 
 	public static String writeRecipe(IRecipe recipe) {
 		int index = 0;
-		String string = "\t<Recipe timeRequired=\"" + recipe.getTime() + "\" power =\"" + recipe.getPower() + "\">\n" +
-				"\t\t<input>\n";
+		StringBuilder string = new StringBuilder("\t<Recipe timeRequired=\"" + recipe.getTime() + "\" power =\"" + recipe.getPower() + "\">\n" +
+				"\t\t<input>\n");
 		for(List<ItemStack> stackList : recipe.getIngredients()) {
 			if(!stackList.isEmpty()) {
 				ItemStack stack = stackList.get(0);
 				String oreStr = recipe.getOreDictString(index++);
 				if(oreStr != null) {
-					string += "\t\t\t<oreDict>" + oreStr + (stack.getCount() > 1 ? (";" + stack.getCount()) : "") + "</oreDict>\n";
+					string.append("\t\t\t<oreDict>").append(oreStr).append(stack.getCount() > 1 ? (";" + stack.getCount()) : "").append("</oreDict>\n");
 				}
 				else {
-					string += "\t\t\t<itemStack>" + stack.getItem().delegate.name() + (stack.getCount() > 1 ? (";" + stack.getCount()) : (stack.getItemDamage() > 0 ? ";1" : "") ) + (stack.getItemDamage() > 0 ? (";" + stack.getItemDamage()) : "") +  "</itemStack>\n";
+					string.append("\t\t\t<itemStack>").append(stack.getItem().delegate.name()).append(stack.getCount() > 1 ? (";" + stack.getCount()) : (stack.getItemDamage() > 0 ? ";1" : "")).append(stack.getItemDamage() > 0 ? (";" + stack.getItemDamage()) : "").append("</itemStack>\n");
 				}
 			}
 		}
 		for(FluidStack stack : recipe.getFluidIngredients()) {
-			string += "\t\t\t<fluidStack>" + FluidRegistry.getDefaultFluidName(stack.getFluid()).split(":")[1] + ";" + stack.amount + "</fluidStack>\n";
+			string.append("\t\t\t<fluidStack>").append(FluidRegistry.getDefaultFluidName(stack.getFluid()).split(":")[1]).append(";").append(stack.amount).append("</fluidStack>\n");
 		}
-		string += "\t\t</input>\n\t\t<output>\n";
+		string.append("\t\t</input>\n\t\t<output>\n");
 
 		for(ItemStack stack : recipe.getOutput()) {
-			string += "\t\t\t<itemStack>" + stack.getItem().delegate.name() + (stack.getCount() > 1 ? (";" + stack.getCount()) : (stack.getItemDamage() > 0 ? ";1" : "") ) + (stack.getItemDamage() > 0 ? (";" + stack.getItemDamage()) : "") +  "</itemStack>\n";
+			string.append("\t\t\t<itemStack>").append(stack.getItem().delegate.name()).append(stack.getCount() > 1 ? (";" + stack.getCount()) : (stack.getItemDamage() > 0 ? ";1" : "")).append(stack.getItemDamage() > 0 ? (";" + stack.getItemDamage()) : "").append("</itemStack>\n");
 		}
 
 		for(FluidStack stack : recipe.getFluidOutputs()) {
-			string += "\t\t\t<fluidStack>" + FluidRegistry.getDefaultFluidName(stack.getFluid()).split(":")[1] + ";" + stack.amount + "</fluidStack>\n";
+			string.append("\t\t\t<fluidStack>").append(FluidRegistry.getDefaultFluidName(stack.getFluid()).split(":")[1]).append(";").append(stack.amount).append("</fluidStack>\n");
 		}
 
-		string += "\t\t</output>\n\t</Recipe>";
+		string.append("\t\t</output>\n\t</Recipe>");
 
-		return string;
+		return string.toString();
 	}
 }

--- a/src/main/java/zmaster587/libVulpes/util/ZUtils.java
+++ b/src/main/java/zmaster587/libVulpes/util/ZUtils.java
@@ -16,6 +16,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.oredict.OreDictionary;
 
+import javax.annotation.Nonnull;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
@@ -97,7 +98,7 @@ public class ZUtils {
 
 			if (oclass != null)
 			{
-				tileentity = (TileEntity)oclass.newInstance();
+				tileentity = oclass.newInstance();
 			}
 		}
 		catch (Throwable throwable1)
@@ -123,7 +124,7 @@ public class ZUtils {
 		}
 		else
 		{
-			net.minecraftforge.fml.common.FMLLog.warning("Skipping BlockEntity with id {}", new Object[] {s});
+			net.minecraftforge.fml.common.FMLLog.warning("Skipping BlockEntity with id {}", s);
 		}
 
 		return tileentity;
@@ -155,14 +156,12 @@ public class ZUtils {
 			maxX = buffer;
 		}
 
-		AxisAlignedBB ret = new AxisAlignedBB(minX,
+		return new AxisAlignedBB(minX,
 				axis.minY,
 				minZ,
 				maxX,
 				axis.maxY,
 				maxZ);
-
-		return ret;
 	}
 
 	/**
@@ -225,20 +224,20 @@ public class ZUtils {
 		return false;
 	}
 
-	public static boolean isInvEmpty(IInventory stack) {
+	public static boolean isInvEmpty(IInventory inv) {
 		boolean empty = true;
-		if(stack == null)
+		if(inv == null)
 			return true;
 
-		for(int i = 0; i < stack.getSizeInventory(); i++) {
-			if(!stack.getStackInSlot(i).isEmpty())
+		for(int i = 0; i < inv.getSizeInventory(); i++) {
+			if(!inv.getStackInSlot(i).isEmpty())
 				return false;
 		}
 
 		return true;
 	}
 
-	public static boolean doesInvHaveRoom(ItemStack item, IInventory inv) {
+	public static boolean doesInvHaveRoom(@Nonnull ItemStack item, IInventory inv) {
 		for(int i = 0; i < inv.getSizeInventory(); i++)
 		{
 			if(inv.getStackInSlot(i).isEmpty() || (item.isItemEqual(inv.getStackInSlot(i)) && inv.getStackInSlot(i).getCount() < inv.getInventoryStackLimit()))
@@ -288,7 +287,7 @@ public class ZUtils {
 			int firstEmtpySlot = -1;
 			int slot;
 
-			if(a[i] != null) {
+			if(!a[i].isEmpty()) {
 				for(slot = 0; slot < b.getSizeInventory(); slot++) {
 
 					if(b.getStackInSlot(slot).isEmpty()) {
@@ -320,11 +319,11 @@ public class ZUtils {
 		}
 	}
 
-	public static void mergeInventory(ItemStack a, IInventory b) {
+	public static void mergeInventory(@Nonnull ItemStack a, IInventory b) {
 		int firstEmtpySlot = -1;
 		int slot;
 
-		if(a != null) {
+		if(!a.isEmpty()) {
 			for(slot = 0; slot < b.getSizeInventory(); slot++) {
 
 				if(b.getStackInSlot(slot).isEmpty()) {
@@ -356,10 +355,11 @@ public class ZUtils {
 		}
 	}
 
-	public static ItemStack getFirstItemInInv(ItemStack i[]) {
+	@Nonnull
+	public static ItemStack getFirstItemInInv(@Nonnull ItemStack i[]) {
 		for(ItemStack stack : i)
 			if(!stack.isEmpty()) return stack;
-		return null;
+		return ItemStack.EMPTY;
 	}
 
 	public static int getFirstFilledSlotIndex(IInventory inv) {
@@ -401,7 +401,7 @@ public class ZUtils {
 		return dist;
 	}
 
-	public static boolean areOresSameTypeOreDict(ItemStack stack1, ItemStack stack2) {
+	public static boolean areOresSameTypeOreDict(@Nonnull ItemStack stack1, @Nonnull ItemStack stack2) {
 		int[] stack1Id = OreDictionary.getOreIDs(stack1);
 		int[] stack2Id = OreDictionary.getOreIDs(stack2);
 
@@ -415,7 +415,7 @@ public class ZUtils {
 		return false;
 	}
 
-	public static boolean isItemInOreDict(ItemStack stack, String oreDictEntry) {
+	public static boolean isItemInOreDict(@Nonnull ItemStack stack, String oreDictEntry) {
 		List<ItemStack> itemStacks = OreDictionary.getOres(oreDictEntry);
 		for(ItemStack stack1 : itemStacks)
 			if(OreDictionary.itemMatches(stack1, stack, false))

--- a/src/main/resources/assets/libvulpes/lang/fr_FR.lang
+++ b/src/main/resources/assets/libvulpes/lang/fr_FR.lang
@@ -1,7 +1,7 @@
 tile.hatch.0.name=Écoutille d'entrée
 tile.hatch.1.name=Écoutille de sortie
-tile.hatch.4.name=Écoutille d'entrée de fluide
-tile.hatch.5.name=Écoutille de sortie de fluide
+tile.hatch.2.name=Écoutille d'entrée de fluide
+tile.hatch.3.name=Écoutille de sortie de fluide
 tile.rfBattery.name=Interface Redstone Flux(RF)
 tile.IC2Plug.name=Interface IC2(EU)
 tile.structureMachine.name=Structure de machine


### PR DESCRIPTION
I used IntelliJ IDEA's code analysis feature to help find warnings and bugs, and manually went through fixing them. The only warnings I let IDEA fix automatically were unused imports and redundant casts.
ItemStacks have been converted to use ItemStack.EMPTY instead of null, to conform to new standards.

Annotations have been added to some of the code to help devs determine when null can and can't be used, however they're nowhere near all-encompassing.

Vague fields and variables have been renamed where I saw them, such as i -> itemStack. This excludes math variables that seemed intentionally named, and standardized names like loop control variables.

I fixed a couple of issues in the French lang fiel, but the non-en_US languages still have some missing translation keys. Probably best for someone who speaks those languages to add the translations, rather than me with Google Translate.

There were some recipes that had invalid json, so I fixed them. This resulted in a few of the recipes changing slightly.

This commit fixes some potential NPEs, though I didn't get them all.


**Next Steps:**
I highly recommend one of the original devs merge this and also run the source through their own IDE's code analysis, since there are still a lot of warnings I couldn't or didn't fix, and a large amount of them could be or turn into bugs.

The ItemStack changes affected some API methods. Mods developed against libVulpes should use builds containing this commit in the future, to prevent them from sending null ItemStacks.

This commit should be used with a [sister-commit for Advanced Rocketry](https://github.com/Advanced-Rocketry/AdvancedRocketry/pull/2142), since the ItemStack refactoring started there.