### PR TITLE
ItemProjector : Fix checking for actual "machineId" NBT tag instead of checking for any NBT data

### DIFF
--- a/src/main/java/zmaster587/libVulpes/items/ItemProjector.java
+++ b/src/main/java/zmaster587/libVulpes/items/ItemProjector.java
@@ -383,7 +383,7 @@ public class ItemProjector extends Item implements IModularInventory, IButtonInv
 	}
 
 	private int getMachineId(ItemStack stack) {
-		if(stack.hasTag()) {
+		if(stack.hasTag() && stack.getTag().contains(IDNAME)) {
 			return stack.getTag().getInt(IDNAME);
 		}
 		else


### PR DESCRIPTION
I was trying to make a modpack and was stumbling upon a very weird crash. 
I narrowed it down to this : 
There was a mod in my list (I still don't know which) that was adding a "temperature" NBT tag to the ItemProjector stack.
When entering ItemProjector.addInformation(), getMachineId returned 0 (the default value since the NBT tag "machineId" was not present) instead of returning -1.

This was because getMachineId only checks if there is any NBT data at all, and not if the tag "machineid" is set.

This simple addition will fix that.

Side note, I still don't know what is adding the mysterious "temperature" tag to the item.